### PR TITLE
#155771410 - Fix for delay incident page showing previous details

### DIFF
--- a/__tests__/TimelineAction.test.jsx
+++ b/__tests__/TimelineAction.test.jsx
@@ -6,7 +6,8 @@ describe('Actions', () => {
   it('should create action to load incident details', () => {
     const expectedAction = {
       type: types.FETCH_INCIDENT,
-      incident: testIncident
+      incident: testIncident,
+      isLoading: false
     };
     expect(actions.loadIncidentSuccess(testIncident)).toEqual(expectedAction);
   });

--- a/mock_endpoints/mockData.js
+++ b/mock_endpoints/mockData.js
@@ -27,7 +27,7 @@ module.exports = {
       levelId: 2,
       locationId: 2,
       updatedAt: '2018-02-13T15:58:06.202Z',
-      assigneeId: 5,
+      assigneeId: 1,
       categoryId: null
     },
     {
@@ -42,7 +42,7 @@ module.exports = {
       levelId: 1,
       locationId: 3,
       updatedAt: '2018-02-13T15:58:06.202Z',
-      assigneeId: 6,
+      assigneeId: 3,
       categoryId: null
     },
     {
@@ -57,7 +57,7 @@ module.exports = {
       levelId: 1,
       locationId: 4,
       updatedAt: '2018-02-13T15:58:06.202Z',
-      assigneeId: 6,
+      assigneeId: 2,
       categoryId: null
     }
   ],

--- a/src/Components/CustomMenu/CustomMenu.Component.jsx
+++ b/src/Components/CustomMenu/CustomMenu.Component.jsx
@@ -3,12 +3,6 @@ import PropTypes from 'prop-types';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 
-const styles = {
-  customWidth: {
-    width: 145
-  }
-};
-
 /**
  * @class CustomMenu
  */
@@ -24,7 +18,10 @@ export class CustomMenu extends React.Component {
   /**
    * Method to handle menu item selection
    */
-  handleChange = (event, index, value) => this.props.changeCountryFilter(value);
+  handleChange = (event, index, value) => {
+    this.props.changeCountryFilter(value);
+    this.setState({ value });
+  };
 
   render() {
     return (
@@ -32,7 +29,7 @@ export class CustomMenu extends React.Component {
         <SelectField
           value={this.state.value}
           onChange={this.handleChange}
-          style={{ ...styles.customWidth, fontSize: '0.8rem', textAlign: 'center', width: '10rem' }}
+          style={{ display: 'block', fontSize: '0.8rem', textAlign: 'center', width: '10rem', padding: '0 auto' }}
         >
           <MenuItem value="All Countries" primaryText="All Countries" />
           <MenuItem value="Kenya" primaryText="Kenya" />

--- a/src/Components/IncidentFilter/IncidentFilter.Component.jsx
+++ b/src/Components/IncidentFilter/IncidentFilter.Component.jsx
@@ -18,17 +18,16 @@ export default class IncidentFilter extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: 1
+      durationFilterValue: 0,
+      flagFilterValue: 'All Incidents'
     };
   }
-
   /**
-   * Method to handle Dropdown Change
-   * Should display the form to add a note to a selected incident
+   * Method to handle change on flag filter drop down
    */
-  handleChange = (event, index, value) => {
-    this.setState({ value });
-    this.props.onSelectStatus(value);
+  handleFlagChange = (event, index, value) => {
+    this.props.filterByType(value);
+    this.setState({ flagFilterValue: value });
   };
 
   render() {
@@ -52,7 +51,7 @@ export default class IncidentFilter extends Component {
           <span className="incidents-label">Show Incidents</span>
 
           <SelectField
-            value={0}
+            value={this.state.durationFilterValue}
             className="duration-filter"
             style={{ fontSize: '0.8rem', textAlign: 'center', width: '9rem' }}
           >
@@ -82,15 +81,18 @@ export default class IncidentFilter extends Component {
           />
 
           <SelectField
-            value={0}
+            value={this.state.flagFilterValue}
+            onChange={this.handleFlagChange}
             className="flag-filter"
             style={{ fontSize: '0.8rem', textAlign: 'center', width: '8rem' }}
           >
-            <MenuItem value={0} primaryText="All flags" onClick={() => { this.props.filterByType('All Incidents'); }}/>
-            <MenuItem value={1} primaryText="Red Flag" onClick={() => { this.props.filterByType('red'); }} />
-            <MenuItem value={2} primaryText="Yellow Flag" onClick={() => { this.props.filterByType('yellow'); }} />
-            <MenuItem value={3} primaryText="Green Flag" onClick={() => { this.props.filterByType('green'); }}/>
+            <MenuItem value={'All Incidents'} primaryText="All flags" />
+            <MenuItem value={'red'} primaryText="Red Flag" />
+            <MenuItem value={'yellow'} primaryText="Yellow Flag" />
+            <MenuItem value={'green'} primaryText="Green Flag" />
           </SelectField>
+
+          <CustomMenu className="country-filter" changeCountryFilter={this.props.changeCountryFilter} />
 
           <div className="toggle-section">
             <span className="toggle-label">Mine</span>
@@ -104,8 +106,6 @@ export default class IncidentFilter extends Component {
 
             <span className="toggle-label">All</span>
           </div>
-
-          <CustomMenu className="country-filter" changeCountryFilter={this.props.changeCountryFilter} />
         </div>
       </div>
     );

--- a/src/Components/IncidentFilter/IncidentFilter.scss
+++ b/src/Components/IncidentFilter/IncidentFilter.scss
@@ -12,9 +12,9 @@
 
 .filters-container {
   @include flex-column;
-  width: 90vw;
+  width: 95vw;
   max-height: 8rem;
-  margin: auto 2rem auto auto !important;
+  margin: auto !important;
 
   .filters {
     @include flex-row;
@@ -50,12 +50,14 @@
     .toggle-section {
       @include flex-row;
       padding: 0 0.5rem;
+      max-width: 2rem !important;
 
       .toggle-label {
         font-weight: 200;
         font-size: 0.8em;
         color: map_get($grey, 300);
-        margin: auto 0.5rem;
+        margin: auto 0.2rem;
+        padding: 0 0.5rem;
       }
     }
 
@@ -66,7 +68,7 @@
 
     .country-filter {
       max-width: 10rem !important;
-      margin: 0 1rem;
+      margin: 0 0.5rem;
     }
 
   }

--- a/src/Components/IncidentList/IncidentList.Component.jsx
+++ b/src/Components/IncidentList/IncidentList.Component.jsx
@@ -19,7 +19,7 @@ export default class IncidentList extends Component {
    * @param {string} flagType - incident flag type
    * @returns {string} flagType URL
    */
-  getIncidentFlag = (flag) => {
+  getIncidentFlag = flag => {
     if (flag.toLowerCase() === 'green') {
       return this.state.flags.green;
     } else if (flag.toLowerCase() === 'yellow') {

--- a/src/actions/timelineAction.jsx
+++ b/src/actions/timelineAction.jsx
@@ -1,5 +1,7 @@
 import * as axios from 'axios';
 import config from '../config/index';
+import { loadingAction } from './LoadingAction';
+import { errorAction } from './errorAction';
 import {
   FETCH_INCIDENT,
   ADD_NOTE,
@@ -24,7 +26,7 @@ const loadChats = incidentId => {
 
 // load Incident Action Creator
 export const loadIncidentSuccess = incident => {
-  return { type: FETCH_INCIDENT, incident };
+  return { type: FETCH_INCIDENT, incident, isLoading: false };
 };
 
 /**
@@ -32,6 +34,7 @@ export const loadIncidentSuccess = incident => {
  */
 export const loadIncidentDetails = incidentId => {
   return dispatch => {
+    dispatch(loadingAction(true));
     return axios
       .all([loadIncident(incidentId), loadNotes(incidentId), loadChats(incidentId)])
       .then(arr => {
@@ -41,7 +44,7 @@ export const loadIncidentDetails = incidentId => {
         dispatch(loadIncidentSuccess(incident));
       })
       .catch(error => {
-        return error;
+        return dispatch(errorAction(error));
       });
   };
 };
@@ -68,7 +71,7 @@ export const addNote = (noteText, incidentId, userId) => {
         dispatch(addNoteSuccess(res.data.data));
       })
       .catch(error => {
-        return error;
+        return dispatch(errorAction(error));
       });
   };
 };
@@ -94,7 +97,7 @@ export const editNote = (noteText, noteId, index) => {
         dispatch(editNoteSuccess(res.data.data, index));
       })
       .catch(error => {
-        return error;
+        return dispatch(errorAction(error));
       });
   };
 };
@@ -112,7 +115,7 @@ export const archiveNote = (noteId, index) => {
         dispatch(archiveNoteSuccess(res.data.data, index));
       })
       .catch(error => {
-        return error;
+        return dispatch(errorAction(error));
       });
   };
 };
@@ -137,7 +140,7 @@ export const changeStatus = (statusId, incidentId) => {
         dispatch(changeStatusSuccess(res.data.data));
       })
       .catch(error => {
-        return error;
+        return dispatch(errorAction(error));
       });
   };
 };
@@ -162,7 +165,7 @@ export const changeAssignee = (assigneeId, incidentId) => {
         dispatch(changeAssigneeSuccess(res.data.data));
       })
       .catch(error => {
-        return error;
+        return dispatch(errorAction(error));
       });
   };
 };
@@ -189,7 +192,7 @@ export const sendMessage = (incidentId, userId, message) => {
         dispatch(sendMessageSuccess(res.data.data));
       })
       .catch(error => {
-        return error;
+        return dispatch(errorAction(error));
       });
   };
 };

--- a/src/pages/Dashboard/Dashboard.Component.jsx
+++ b/src/pages/Dashboard/Dashboard.Component.jsx
@@ -30,7 +30,6 @@ export class Dashboard extends Component {
     };
   }
 
-
   componentDidMount() {
     this.props.loadIncidents();
   }
@@ -42,7 +41,7 @@ export class Dashboard extends Component {
   }
 
   changeTypeFilter() {
-    return (key) => {
+    return key => {
       this.setState({ typeFilterKey: key });
     };
   }
@@ -52,17 +51,16 @@ export class Dashboard extends Component {
 
     // filter by countries
     if (this.state.filterKey !== 'All Countries') {
-      incidents = incidents.filter((incident) => {
+      incidents = incidents.filter(incident => {
         return this.state.filterKey.toLocaleLowerCase() === incident.Location.country.toLowerCase();
-
       });
     }
 
     // filter country by  incident's Type
     if (this.state.typeFilterKey !== 'All Incidents') {
-      incidents = incidents.filter((incident) => {
+      incidents = incidents.filter(incident => {
         const stateKey = this.state.typeFilterKey.toLocaleLowerCase();
-        return incident.Level && (stateKey === incident.Level.name.toLocaleLowerCase());
+        return incident.Level && stateKey === incident.Level.name.toLocaleLowerCase();
       });
     }
     return incidents;
@@ -70,9 +68,7 @@ export class Dashboard extends Component {
 
   render() {
     const incidents = this.filterIncidents();
-    const isLoading = this.props.isLoading;
-    const isError = this.props.isError;
-    const error = this.props.errorMessage;
+    const { isLoading, isError, errorMessage } = this.props;
 
     return (
       <div>
@@ -80,19 +76,22 @@ export class Dashboard extends Component {
         {isLoading ? (
           <CircularProgressIndicator />
         ) : (
-            <div>
-              <IncidentFilter incident={this.state.selectedIncident} changeCountryFilter={this.changeFilter()}
-                filterByType={this.changeTypeFilter()} />
-              <div className="dashboard-container">
-                {<IncidentList incidents={incidents} onSelect={this.handleSelectedIncident} />}
-              </div>
+          <div>
+            <IncidentFilter
+              incident={this.state.selectedIncident}
+              changeCountryFilter={this.changeFilter()}
+              filterByType={this.changeTypeFilter()}
+            />
+            <div className="dashboard-container">
+              {<IncidentList incidents={incidents} onSelect={this.handleSelectedIncident} />}
             </div>
-          )}
+          </div>
+        )}
         {isError ? (
-          <CustomNotification type={'error'} message={error} autoHideDuration={15000} open />
+          <CustomNotification type={'error'} message={errorMessage} autoHideDuration={15000} open />
         ) : (
-            <CustomNotification type={'error'} message={error} open={false} />
-          )}
+          <CustomNotification type={'error'} message={errorMessage} open={false} />
+        )}
 
         {this.props.location.state ? (
           <CustomNotification
@@ -101,8 +100,8 @@ export class Dashboard extends Component {
             open={this.props.location.state.open}
           />
         ) : (
-            <CustomNotification type="default" message="" open={false} />
-          )}
+          <CustomNotification type="default" message="" open={false} />
+        )}
       </div>
     );
   }

--- a/src/pages/IncidentTimeline/IncidentTimeline.Component.jsx
+++ b/src/pages/IncidentTimeline/IncidentTimeline.Component.jsx
@@ -3,7 +3,6 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'material-ui/Tabs';
-import { Redirect } from 'react-router-dom';
 
 // actions
 import {
@@ -22,6 +21,7 @@ import './IncidentTimeline.scss';
 
 // Components
 import NavBar from '../../Common/NavBar/NavBar.Component';
+import CustomNotification from '../../Components/CustomNotification/CustomNotification.Component';
 import TimelineSidebar from '../../Components/TimelineSidebar/TimelineSidebar.Component';
 import TimelineNotes from '../../Components/TimelineNotes/TimelineNotes.Component';
 import TimelineChat from '../../Components/TimelineChat/TimelineChat.Component';
@@ -33,10 +33,6 @@ import CircularProgressIndicator from '../../Components/Progress/Progress.Compon
 export class IncidentTimeline extends Component {
   constructor(props) {
     super(props);
-    this.state = {
-      incident: {},
-      redirect: false
-    };
   }
 
   componentDidMount() {
@@ -49,23 +45,12 @@ export class IncidentTimeline extends Component {
   }
 
   render() {
-    const { redirect } = this.state;
-    if (redirect) {
-      return (
-        <Redirect
-          to={{
-            pathname: '/dashboard',
-            state: { open: true, type: 'error', message: 'Incident not found. Try again.' }
-          }}
-        />
-      );
-    }
+    const { isLoading, isError, errorMessage } = this.props;
 
     return (
       <div>
         <NavBar {...this.props} />
-
-        {this.props.match.params.incidentId && this.props.incident.id ? (
+        {!isLoading && this.props.incident.id ? (
           <div className="timeline-container">
             <TimelineSidebar className="timeline-sidebar" {...this.props} />
 
@@ -81,9 +66,13 @@ export class IncidentTimeline extends Component {
             </div>
           </div>
         ) : (
-          <div>
-            <CircularProgressIndicator>{/* this.handleRedirect() */}</CircularProgressIndicator>
-          </div>
+          <CircularProgressIndicator />
+        )}
+
+        {isError ? (
+          <CustomNotification type={'error'} message={errorMessage} autoHideDuration={15000} open />
+        ) : (
+          <CustomNotification type={'error'} message={''} open={false} />
         )}
       </div>
     );
@@ -98,7 +87,10 @@ IncidentTimeline.propTypes = {
   match: PropTypes.object.isRequired,
   incident: PropTypes.object,
   fetchStaff: PropTypes.func,
-  staff: PropTypes.array
+  staff: PropTypes.array,
+  isLoading: PropTypes.bool.isRequired,
+  isError: PropTypes.bool.isRequired,
+  errorMessage: PropTypes.string.isRequired
 };
 
 /**
@@ -109,7 +101,10 @@ IncidentTimeline.propTypes = {
 const mapStateToProps = state => {
   return {
     incident: state.selectedIncident,
-    staff: state.staff
+    staff: state.staff,
+    isLoading: state.isLoading,
+    isError: state.error.status,
+    errorMessage: state.error.message
   };
 };
 

--- a/src/reducers/loadingReducer.jsx
+++ b/src/reducers/loadingReducer.jsx
@@ -1,5 +1,5 @@
 import initialState from './initialState';
-import { IS_LOADING, ERROR_ACTION, FETCH_INCIDENTS_SUCCESS } from '../actions/actionTypes';
+import { IS_LOADING, ERROR_ACTION, FETCH_INCIDENTS_SUCCESS, FETCH_INCIDENT } from '../actions/actionTypes';
 
 const loadingReducer = (state = initialState.isLoading, action) => {
   switch (action.type) {
@@ -7,6 +7,9 @@ const loadingReducer = (state = initialState.isLoading, action) => {
       return action.status;
 
     case FETCH_INCIDENTS_SUCCESS:
+      return action.isLoading;
+
+    case FETCH_INCIDENT:
       return action.isLoading;
 
     case ERROR_ACTION:


### PR DESCRIPTION
#### What does this PR do?
Fix delay incident page showing previous details

#### Description of Task to be completed?
When you load incident 1 then go back to the incident list and click on incident 2, it shows the details for incident 1 momentarily before updating to incident 2's details.

It should show a loader instead of previous data.

#### Where should the reviewer start?
File changes on PR

#### How should this be manually tested?
- Create a .env file based on .env.template.
- Run in development mode by setting NODE_ENV=development in .env
- Open the dashboard and click on an incident's subject to view the timeline page
- Go back to the dashboard and click on a different incident or use search

#### What are the relevant pivotal tracker stories?
[#155771410](https://www.pivotaltracker.com/story/show/155771410)

#### Issue on Github
#47 
