### PR TITLE
chore: Fix persistent error message bug

### DIFF
--- a/__tests__/StaffAction.test.jsx
+++ b/__tests__/StaffAction.test.jsx
@@ -24,7 +24,8 @@ describe('async actions', () => {
     },
     {
       type: types.FETCH_STAFF,
-      staff: users
+      staff: users,
+      isError: false
     },
     { type: types.ERROR_ACTION,
       status: true,

--- a/__tests__/TimelineAction.test.jsx
+++ b/__tests__/TimelineAction.test.jsx
@@ -34,7 +34,8 @@ describe('async actions', () => {
     {
       type: types.FETCH_INCIDENT,
       incident: testIncident,
-      isLoading: false
+      isLoading: false,
+      isError: false
     },
     {
       type: types.ADD_NOTE,

--- a/src/actions/incidentAction.jsx
+++ b/src/actions/incidentAction.jsx
@@ -9,7 +9,8 @@ export const loadIncidentsSuccess = incidents => {
   return {
     type: FETCH_INCIDENTS_SUCCESS,
     incidents,
-    isLoading: false
+    isLoading: false,
+    isError: false
   };
 };
 

--- a/src/actions/staffAction.jsx
+++ b/src/actions/staffAction.jsx
@@ -6,7 +6,7 @@ import { errorAction } from './errorAction';
 
 // Fetch staff action creator
 export const fetchStaffSuccess = staff => {
-  return { type: FETCH_STAFF, staff };
+  return { type: FETCH_STAFF, staff, isError: false };
 };
 
 export const fetchStaff = () => {

--- a/src/actions/timelineAction.jsx
+++ b/src/actions/timelineAction.jsx
@@ -26,7 +26,7 @@ const loadChats = incidentId => {
 
 // load Incident Action Creator
 export const loadIncidentSuccess = incident => {
-  return { type: FETCH_INCIDENT, incident, isLoading: false };
+  return { type: FETCH_INCIDENT, incident, isLoading: false, isError: false };
 };
 
 /**

--- a/src/pages/IncidentTimeline/IncidentTimeline.Component.jsx
+++ b/src/pages/IncidentTimeline/IncidentTimeline.Component.jsx
@@ -37,8 +37,8 @@ export class IncidentTimeline extends Component {
   }
 
   componentDidMount() {
-    this.props.loadIncidentDetails(this.props.match.params.incidentId);
     this.props.fetchStaff();
+    this.props.loadIncidentDetails(this.props.match.params.incidentId);
   }
 
   handleRedirect() {
@@ -51,7 +51,13 @@ export class IncidentTimeline extends Component {
     return (
       <div>
         <NavBar {...this.props} />
-        {!isLoading && this.props.incident.id ? (
+        {isLoading ? (<CircularProgressIndicator />) : null}
+        {isError ? (
+          <CustomNotification type={'error'} message={errorMessage} autoHideDuration={1500000} open />
+        ) : (
+          <CustomNotification type={'error'} message={errorMessage} open={false} />
+        )}
+        {this.props.incident.id ? (
           <div className="timeline-container">
             <TimelineSidebar className="timeline-sidebar" {...this.props} />
 
@@ -66,15 +72,7 @@ export class IncidentTimeline extends Component {
               </Tabs>
             </div>
           </div>
-        ) : (
-          <CircularProgressIndicator />
-        )}
-
-        {isError ? (
-          <CustomNotification type={'error'} message={errorMessage} autoHideDuration={15000} open />
-        ) : (
-          <CustomNotification type={'error'} message={''} open={false} />
-        )}
+        ) : null}
       </div>
     );
   }

--- a/src/reducers/errorReducer.jsx
+++ b/src/reducers/errorReducer.jsx
@@ -1,5 +1,5 @@
 import initialState from './initialState';
-import { ERROR_ACTION } from '../actions/actionTypes';
+import { ERROR_ACTION, FETCH_INCIDENTS_SUCCESS, FETCH_INCIDENT, FETCH_STAFF } from '../actions/actionTypes';
 
 const errorReducer = (state = initialState.error, action) => {
   switch (action.type) {
@@ -7,6 +7,24 @@ const errorReducer = (state = initialState.error, action) => {
       return {
         status: action.status,
         message: action.message
+      };
+
+    case FETCH_INCIDENTS_SUCCESS:
+      return {
+        status: action.isError,
+        message: ''
+      };
+
+    case FETCH_INCIDENT:
+      return {
+        status: action.isError,
+        message: ''
+      };
+
+    case FETCH_STAFF:
+      return {
+        status: action.isError,
+        message: ''
       };
 
     default:

--- a/src/reducers/initialState.jsx
+++ b/src/reducers/initialState.jsx
@@ -1,6 +1,5 @@
 export default {
   incidents: [],
-  notes: [],
   isLoading: false,
   error: {
     status: false,


### PR DESCRIPTION
#### What does this PR do?
- Fixes the following error:
  Upon visiting the timeline of a non-existent incident, eg. `http://wire.andela.com:8080/timeline/123456` - assuming it doesn't exist, of course - one would expect the error part of the state to be updated, which does indeed happen:
```
error: {
    status: true,
    message: 'The requested resource could not be found.'
  }
```
However, upon navigating back to the dashboard, one would expect that, if there are no errors fetching incidents from the API, that the error part of the state looks like:
```
error: {
    status: false,
    message: null
  }
```
Instead, the error state bears the same error as before:
```
error: {
    status: true,
    message: 'The requested resource could not be found.'
  }
```
This PR fixes that.
#### Where should the reviewer start?
View file changes in PR
#### How should this be manually tested?
- Attempt to reproduce the same error as above. 
#### What are the relevant pivotal tracker stories?
[#156612567](https://www.pivotaltracker.com/story/show/156612567)
#### Screenshots (if appropriate)
N/A
