### PR TITLE
#154084329 - chore: Restrict login to admins only

### DIFF
--- a/mock_endpoints/mockControllers.js
+++ b/mock_endpoints/mockControllers.js
@@ -235,5 +235,14 @@ module.exports = {
     return users.filter(user => {
       return user.roleId !== 1;
     });
+  },
+  login: (email) => {
+    if (email) {
+      let userToCheck = users.filter(user => {
+        return user.email == email;
+      });
+      return userToCheck[0].roleId !== 1;
+    }
+    return false;
   }
 };

--- a/mock_endpoints/mockData.js
+++ b/mock_endpoints/mockData.js
@@ -267,6 +267,13 @@ module.exports = {
       username: 'Robley Gori',
       imageUrl: 'https://lh6.googleusercontent.com/-tVq8OIwPjOw/AAAAAAAAAAI/AAAAAAAAAAo/t3GsqCgqrNk/photo.jpg?sz=50',
       roleId: 3
+    },
+    {
+      id: '-KlxFba7RDN80Dg3Abgw',
+      email: 'peter.musonye@andela.com',
+      username: 'Peter Musonye',
+      imageUrl: 'https://lh3.googleusercontent.com/-Jlt5VItDH60/AAAAAAAAAAI/AAAAAAAAAAc/sFHgXrT4PBs/photo.jpg?sz=50',
+      roleId: 1 
     }
   ],
   locations: [

--- a/mock_endpoints/mockMiddleware.js
+++ b/mock_endpoints/mockMiddleware.js
@@ -13,7 +13,8 @@ const {
   changeAssignee,
   handleCCd,
   changeStatus,
-  getStaff
+  getStaff,
+  login
 } = require('./mockControllers');
 
 module.exports = {
@@ -101,6 +102,11 @@ module.exports = {
   fetchStaff: (req, res) => {
     setTimeout(() => {
       res.send({ data: { users: getStaff() }, status: 'success' });
+    }, 2000);
+  },
+  login: (req, res) => {
+    setTimeout(() => {
+      res.send({userToken: login(req.body.email), status: 'success' });
     }, 2000);
   }
 };

--- a/server.js
+++ b/server.js
@@ -42,6 +42,9 @@ if (process.env.NODE_ENV === 'development') {
   // Staff route
   app.get('/api/users', mockMiddleware.fetchStaff);
 
+  // Login route
+  app.post('/api/users/login', mockMiddleware.login);
+
   app.use('*', function(req, res, next) {
     let filename = path.join(compiler.outputPath, 'index.html');
     compiler.outputFileSystem.readFile(filename, function(err, result) {
@@ -55,8 +58,8 @@ if (process.env.NODE_ENV === 'development') {
   });
 
   app.use(function (err, req, res, next) {
-    res.status(500).send('Something broke!')
-  })
+    res.status(500).send('Something broke!');
+  });
 } else if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging') {
   // Configuration for production environment
   app.use(express.static(path.join(__dirname, 'dist')));

--- a/src/actions/errorAction.jsx
+++ b/src/actions/errorAction.jsx
@@ -4,7 +4,7 @@ import { ERROR_ACTION } from './actionTypes';
 export const errorAction = error => {
   let message;
   switch (error.response.status) {
-    case 401:
+    case 401 || 403:
       message = 'You might not be logged in/authorized. Please try again.';
       break;
     case 404:

--- a/src/actions/incidentAction.jsx
+++ b/src/actions/incidentAction.jsx
@@ -17,11 +17,14 @@ export const loadIncidentsSuccess = incidents => {
 /**
  * loadIncident Thunk
  */
+
 export const loadIncidents = () => {
+  let token = localStorage.getItem('token');
+  let headers = {'Authorization': token};
   return dispatch => {
     dispatch(loadingAction(true));
     return axios
-      .get(config.INCIDENTS_URL)
+      .get(config.INCIDENTS_URL, {headers})
       .then(incidents => {
         dispatch(
           loadIncidentsSuccess(
@@ -48,11 +51,13 @@ export const changeStatusSuccess = incidentId => {
  * @param {*} incidentId
  */
 export const changeStatus = (statusId, incidentId) => {
+  let token = localStorage.getItem('token');
+  let headers = {'Authorization': token};
   return dispatch => {
     return axios
       .put(`${config.INCIDENTS_URL}/${incidentId}/`, {
         statusId: statusId
-      })
+      }, {headers})
       .then(res => {
         dispatch(changeStatusSuccess(res.data.data));
       })

--- a/src/actions/timelineAction.jsx
+++ b/src/actions/timelineAction.jsx
@@ -13,7 +13,8 @@ import {
 } from './actionTypes';
 
 const loadIncident = incidentId => {
-  return axios.get(`${config.INCIDENTS_URL}/${incidentId}`);
+  let headers = {'Authorization': localStorage.token};
+  return axios.get(`${config.INCIDENTS_URL}/${incidentId}`, {headers});
 };
 
 const loadNotes = incidentId => {
@@ -132,11 +133,12 @@ export const changeStatusSuccess = incident => {
  * @param {*} incidentId
  */
 export const changeStatus = (statusId, incidentId) => {
+  let headers = {'Authorization': localStorage.token};
   return dispatch => {
     return axios
       .put(`${config.INCIDENTS_URL}/${incidentId}/`, {
         statusId: statusId
-      })
+      }, {headers})
       .then(res => {
         dispatch(changeStatusSuccess(res.data.data));
       })
@@ -157,11 +159,12 @@ export const changeAssigneeSuccess = incident => {
  * @param {*} incidentId
  */
 export const changeAssignee = payload => {
+  let headers = {'Authorization': localStorage.token};
   return dispatch => {
     return axios
       .put(`${config.INCIDENTS_URL}/${payload.incidentId}/`, {
         assignee: payload
-      })
+      }, {headers})
       .then(res => {
         dispatch(changeAssigneeSuccess(res.data.data));
       })
@@ -183,11 +186,12 @@ export const changeCCdSuccess = incident => {
  * @param {*} status
  */
 export const handleCC = payload => {
+  let headers = {'Authorization': localStorage.token};
   return dispatch => {
     return axios
       .put(`${config.INCIDENTS_URL}/${payload.incidentId}/`, {
         ccd: payload.ccdUsers
-      })
+      }, {headers})
       .then(res => {
         dispatch(changeCCdSuccess(res.data.data));
       })

--- a/src/helpers/auth.js
+++ b/src/helpers/auth.js
@@ -23,22 +23,16 @@ const authenticateUser = {
   /**
    * Check if user info is credible
    * and user can be authorized.
-   * check if is WIRE admin
    */
   validateUser() {
     const userInfo = decodeToken();
 
     if (this.andelaEmailRegex.test(userInfo.email)) {
-      /**
-       * TODO: update to authenticating only WIRE admins
-       *       Get admin info from WIRE API
-       */
       if (userInfo.roles.Andelan) {
         localStorage.setItem('user', userInfo.name);
         localStorage.setItem('user_avatar', userInfo.picture);
         localStorage.setItem('userId', userInfo.id);
         localStorage.setItem('email', userInfo.email);
-        this.isAuthenticated = true;
         return true;
       }
       return false;
@@ -51,6 +45,7 @@ const authenticateUser = {
    */
   logoutUser() {
     this.removeToken();
+    localStorage.clear();
     location.reload();
   },
 

--- a/src/pages/Login/LoginPage.Component.jsx
+++ b/src/pages/Login/LoginPage.Component.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
 import RaisedButton from 'material-ui/RaisedButton';
+import * as axios from 'axios';
 
 //styling
 import './LoginPage.scss';
@@ -16,14 +17,37 @@ import authenticateUser from '../../helpers/auth';
  * LoginPage class
  */
 class LoginPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      userToken: ''
+    };
+  }
+
+  componentDidMount() {
+    authenticateUser.authenticate();
+    this.login(localStorage.getItem('email'));
+  }
+
+  login = email => {
+    let loginUrl = `${config.API_URL}/users/login`;
+    if (email) {
+      axios.post(loginUrl, {email})
+      .then(response => {
+        this.setState({
+          userToken: response.data.userToken
+        });
+      });
+    }
+  }
+
   render() {
     const { from } = this.props.location.state || { from: { pathname: '/' } };
-
     setReferrerInlocationStorage(from.pathname);
-    authenticateUser.authenticate();
     const referrer = getReferrerInlocationStorage();
+    localStorage.setItem('token', this.state.userToken);
 
-    if (authenticateUser.isAuthenticated) {
+    if (authenticateUser.isAuthenticated && this.state.userToken) {
       return <Redirect to={(from.pathname = referrer)} />;
     }
 

--- a/src/pages/Search/Search.Component.jsx
+++ b/src/pages/Search/Search.Component.jsx
@@ -28,9 +28,11 @@ class SearchComponent extends Component {
    * Method to handle search input change
    */
   handleInputChange = () => {
+    let token = localStorage.getItem('token');
+    let headers = {'Authorization': token};
     let searchQuery = this.nameInput.input.value.toLowerCase();
     if (searchQuery) {
-      axios.get(config.SEARCH_INCIDENTS_URL + '?q=' + searchQuery).then(response => {
+      axios.get(config.SEARCH_INCIDENTS_URL + '?q=' + searchQuery, {headers}).then(response => {
         this.setState({
           incidents: response.data.data.incidents
         });


### PR DESCRIPTION
#### What does this PR do?
- Users need authorization from the backend before proceeding past the login page
- All API calls involving incidents include an `Authorization` header with the token obtained at login
- Although any registered user can log in, only designated admins can receive data back from the backend. Everyone else sees a snackbar informing them of their lack of this privilege
#### Where should the reviewer start?
View file changes in PR.
#### How should this be manually tested?
- Although this PR includes a simple implementation of this with the mock API, I'd recommend using the locally hosted API
- Fire up WIRE API on localhost. By default, it will be on port 3000.
- Change line 10 of `index.js` from ``${window.location.protocol}//${window.location.host}/api`` to `'http://localhost:3000/api'`
- On the frontend, visit `/login` and proceed.
- Users who exist in the API db will be allowed to proceed, and view incidents, update them, etc.
- Users who don't exist in the db cannot proceed from the login page
- Users who exist but are not admins or super admins see a snackbar informing them that they are not authorized 
#### What are the relevant pivotal tracker stories?
[#154084329](https://www.pivotaltracker.com/story/show/154084329)
#### Screenshots (if appropriate)
N/A
