### PR TITLE
fix: Make navigating to different url smooth

### DIFF
--- a/src/Components/PrivateRoute/PrivateRoute.Component.jsx
+++ b/src/Components/PrivateRoute/PrivateRoute.Component.jsx
@@ -9,6 +9,7 @@ import authenticateUser from '../../helpers/auth';
  * PrivateRoute Component
  */
 const PrivateRoute = ({ component: Component, ...rest }) => {
+  authenticateUser.authenticate();
   return (
     <Route
       {...rest}


### PR DESCRIPTION
#### What does this PR do?
- When attempting to navigate from one incident, manually, say
 `http://wire.andela.com:8080/timeline/1` to `http://wire.andela.com:8080/timeline/2`, the
  router redirects to `/login` first before resolving the intended url.
- This commit fixes that.
#### Where should the reviewer start?
- View file changes in PR
#### How should this be manually tested?
- Attempt to reproduce the bug as described above.