### PR TITLE
chore: Make incident section headings sticky

### DIFF
--- a/__tests__/IncidentSection.test.jsx
+++ b/__tests__/IncidentSection.test.jsx
@@ -8,7 +8,7 @@ describe('IncidentCard component', () => {
   it('should render no cards when there are no incidents', () => {
     const incidentSection = shallow(<IncidentSection incidentStatus={'PENDING'} incidents={[]} />);
     expect(incidentSection.find('div .incident-status').text()).toEqual('PENDING');
-    expect(incidentSection.find('div .incident-cards > .no-incidents').text()).toEqual(' No incidents in PENDING');
+    expect(incidentSection.find('div .card-wrapper > .no-incidents').text()).toEqual(' No incidents in PENDING');
     expect(incidentSection.find('IncidentCard').exists()).toEqual(false);
   });
 

--- a/src/Components/IncidentList/IncidentList.scss
+++ b/src/Components/IncidentList/IncidentList.scss
@@ -21,159 +21,165 @@
     margin: 2rem 0.5rem;
 
     .incident-cards {
-      flex-direction: column;
-      align-items: center;
       height: 65vh;
-      overflow-y: scroll;
-      justify-content: space-between;
       border-radius: 8px;
       background-color: #ffffff;
       box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
+      position: relative;
 
       .incident-status {
         font-family: 'DIN Pro Light';
         font-weight: 300;
-        position: relative;
-        top: 1rem;
-        left: 1rem;
-        margin-left: 1.5%;
+        font-size: 1vw;
+        position: sticky;
+        top: 2.5vh;
+        margin-left: 5%;
       }
 
       .underline {
-        width: 150px;
-        height: 5px;
+        width: 8vw;
+        height: 0.5vh;
         border-radius: 5px;
-        position: relative;
-        margin-left: 1.5%;
-        margin-bottom: 4rem;
-        top: 2rem;
-        left: 1rem;
+        position: sticky;
+        margin-left: 5%;
+        margin-bottom: 13%;
+        top: 6vh;
       }
 
-      .no-incidents {
-        display: flex;
+      .card-wrapper {
+        position: absolute;
+        bottom: 0;
         flex-direction: column;
-        font-size: 1rem;
-        font-weight: 300;
-        align-items: center;
-        justify-content: center;
+        height: 55vh;
+        width: 100%;
+        overflow-y: scroll;
+        justify-content: space-between;
 
-        .folder {
-          font-size: 5rem;
-          margin-top: 7rem;
-          width: 6rem;
-          height: 5rem;
-        }
-
-        p {
-          position: relative;
-          text-align: center !important;
-          vertical-align: middle !important;
-          color: #3960ad;
-          font-family: 'DIN Pro Extra Light';
-        }
-
-        .status {
-          font-style: italic;
-          color: rgba(57, 96, 173, 0.6);
-        }
-      }
-
-      .incident-card {
-        display: flex;
-        flex-direction: column;
-        margin: 5%;
-        min-height: 9rem;
-        height: auto;
-        opacity: 0.8;
-        border-radius: 5px;
-        border: solid 1px rgba(0, 0, 0, 0.2);
-        box-shadow: none;
-
-        a {
-          text-decoration: none !important;
-          color: inherit !important;
-        }
-
-        .card-header {
+        .no-incidents {
           display: flex;
-          flex-direction: row;
-          flex-wrap: wrap;
-          margin-bottom: 0;
+          flex-direction: column;
+          font-size: 1rem;
+          font-weight: 300;
+          align-items: center;
+          justify-content: center;
 
-          .incident-report-date {
-            margin: 3% 0 0 5%;
-            color: #95989a;
-            font-size: 0.85rem;
+          .folder {
+            font-size: 5rem;
+            margin-top: 7rem;
+            width: 6rem;
+            height: 5rem;
           }
 
-          .incident-time {
+          p {
+            position: relative;
+            text-align: center !important;
+            vertical-align: middle !important;
+            color: #3960ad;
+            font-family: 'DIN Pro Extra Light';
+          }
+
+          .status {
             font-style: italic;
-            margin: 3% 3% 0 1%;
-            color: #95989a;
-            font-size: 0.85rem;
+            color: rgba(57, 96, 173, 0.6);
+          }
+        }
+
+        .incident-card {
+          display: flex;
+          flex-direction: column;
+          margin: 0% 5% 5% 5%;
+          min-height: 9rem;
+          height: auto;
+          opacity: 0.8;
+          border-radius: 5px;
+          border: solid 1px rgba(0, 0, 0, 0.2);
+          box-shadow: none;
+
+          a {
+            text-decoration: none !important;
+            color: inherit !important;
           }
 
-          .incident-flag {
-            width: 2rem;
-            height: 2rem;
-            margin-left: auto;
-            margin-top: 3%;
+          .card-header {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
             margin-bottom: 0;
 
-            .flag-image {
-              width: 0.8rem;
-              height: 1.2rem;
+            .incident-report-date {
+              margin: 3% 0 0 5%;
+              color: #95989a;
+              font-size: 0.85rem;
             }
 
-            &:hover {
-              cursor: pointer;
+            .incident-time {
+              font-style: italic;
+              margin: 3% 3% 0 1%;
+              color: #95989a;
+              font-size: 0.85rem;
+            }
+
+            .incident-flag {
+              width: 2rem;
+              height: 2rem;
+              margin-left: auto;
+              margin-top: 3%;
+              margin-bottom: 0;
+
+              .flag-image {
+                width: 0.8rem;
+                height: 1.2rem;
+              }
+
+              &:hover {
+                cursor: pointer;
+              }
             }
           }
-        }
 
-        .incident-subject {
-          margin: 0 3% 3% 5%;
-          color: #000000;
-          font-size: 1.2rem;
-        }
-
-        .incident-description {
-          margin: 0% 3% 3% 5%;
-          font-size: 0.7rem;
-          color: rgba(0, 0, 0, 0.7);
-        }
-
-        .assigned-to {
-          display: flex;
-          flex-direction: row;
-          margin-bottom: 1%;
-
-          .assignee {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            padding: 4px;
-            margin: 0% -2.5% 3% 5%;
-            width: 2rem;
-            height: 1rem;
-            border-radius: 3px;
-            font-size: 0.7rem;
+          .incident-subject {
+            margin: 0 3% 3% 5%;
+            color: #000000;
+            font-size: 1.2rem;
           }
 
-          .unassigned {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            padding: 6px;
-            margin: 0% -2.5% 3% 5%;
-            width: 4rem;
-            height: 1rem;
-            border-radius: 3px;
-            background-color: #f1f6f8;
+          .incident-description {
+            margin: 0% 3% 3% 5%;
             font-size: 0.7rem;
+            color: rgba(0, 0, 0, 0.7);
+          }
+
+          .assigned-to {
+            display: flex;
+            flex-direction: row;
+            margin-bottom: 1%;
+
+            .assignee {
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              justify-content: center;
+              padding: 4px;
+              margin: 0% -2.5% 3% 5%;
+              width: 2rem;
+              height: 1rem;
+              border-radius: 3px;
+              font-size: 0.7rem;
+            }
+
+            .unassigned {
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              justify-content: center;
+              padding: 6px;
+              margin: 0% -2.5% 3% 5%;
+              width: 4rem;
+              height: 1rem;
+              border-radius: 3px;
+              background-color: #f1f6f8;
+              font-size: 0.7rem;
+            }
           }
         }
       }

--- a/src/Components/IncidentList/IncidentSection.Component.jsx
+++ b/src/Components/IncidentList/IncidentSection.Component.jsx
@@ -24,10 +24,10 @@ class IncidentSection extends Component {
   render() {
     const { incidentStatus, incidents, underLineColor } = this.props;
     return (
-      <div>
-        <div className="incident-cards">
-          <span className="incident-status">{incidentStatus}</span>
-          <div className="underline" style={{ backgroundColor: underLineColor }} />
+      <div className="incident-cards">
+        <span className="incident-status">{incidentStatus}</span>
+        <div className="underline" style={{ backgroundColor: underLineColor }} />
+        <div className="card-wrapper">
           {incidents.length ? (
             incidents.map(incident => (
               <IncidentCard

--- a/src/Components/IncidentType/IncidentType.scss
+++ b/src/Components/IncidentType/IncidentType.scss
@@ -4,7 +4,6 @@
   display: flex;
   justify-content: space-between;
   flex-direction: row;
-  position: relative;
 
   .incident-type {
     display: flex;
@@ -22,21 +21,22 @@
       background-color: #ffffff;
       border-radius: 8px;
       box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
+      position: relative;
 
       .incident-type-status {
         font-family: 'DIN Pro Light';
         font-weight: 300;
-        font-size: 1vw;
+        font-size: 1rem;
         position: absolute;
-        top: 6vh;
+        top: 3vh;
       }
 
       .incident-type-underline {
-        width: 8vw;
+        width: 8rem;
         height: 0.5vh;
         border-radius: 5px;
         position: absolute;
-        top: 10.5vh;
+        top: 7vh;
       }
 
       .incident-type-cards {
@@ -47,9 +47,10 @@
         align-content: flex-start;
         box-sizing: border-box;
         width: 85.56vw;
-        height: 61vh;
+        height: 50vh;
         overflow-x: scroll;
-        padding-top: 12vh;
+        position: absolute;
+        bottom: 4vh;
 
         &::-webkit-scrollbar {
           height: 9px;
@@ -70,9 +71,9 @@
           flex-direction: column;
           font-size: 1rem;
           font-weight: 300;
-          align-self: center;
-          align-items: center;
-          justify-content: center;
+          width: 6rem;
+          position: relative;
+          left: 47%;
 
           .folder {
             font-size: 5rem;
@@ -83,7 +84,7 @@
 
           p {
             position: relative;
-            text-align: center !important;
+            text-align: center;
             vertical-align: middle !important;
             color: #3960ad;
             font-family: 'DIN Pro Extra Light';


### PR DESCRIPTION
#### What does this PR do?
- In /dashboard, the default filter is 'Pending', but when one filters for
  'All Incidents', upon scrolling up when on, for instance, the 'Pending'
  section, the heading scrolls as well.
- This commit fixes that.
#### Where should the reviewer start?
View file changes in PR
#### How should this be manually tested?
Fire up localhost, login, and filter incidents by `All Incidents`. Then try scrolling in the `Pending` section.
#### Screenshots (if appropriate)
![Uploading image.png…]()