### PR TITLE
chore: Prevent auto login

### DIFF
--- a/__tests__/TimelineAction.test.jsx
+++ b/__tests__/TimelineAction.test.jsx
@@ -66,7 +66,8 @@ describe('async actions', () => {
     {
       type: types.ERROR_ACTION,
       status: true,
-      message: 'You might not be logged in/authorized. Please try again.'
+      message: 'You might not be logged in/authorized. Please try again.',
+      statusCode: 401,
     }
   ];
 

--- a/__tests__/incidentAction.test.jsx
+++ b/__tests__/incidentAction.test.jsx
@@ -116,10 +116,10 @@ describe('async actions', () => {
     const store = mockStore();
     const newIncident = testIncident;
     const expectedActions = [
-      { type: types.CHANGE_STATUS, 
+      { type: types.CHANGE_STATUS,
         incidentId: newIncident.id }
       ];
-    
+
     newIncident['statusId'] = 2;
 
     store.dispatch(actions.changeStatus(2,1));
@@ -129,7 +129,7 @@ describe('async actions', () => {
         status : 200,
         response : {
           status : 200,
-          data : newIncident.id    
+          data : newIncident.id
         }
       };
       request.respondWith(statusResponse).then(()=>{
@@ -144,13 +144,14 @@ describe('async actions', () => {
     const store = mockStore();
     const newIncident = testIncident;
     const expectedActions = [
-        { 
-          type: types.ERROR_ACTION, 
+        {
+          type: types.ERROR_ACTION,
           status: true,
-          message: 'The requested resource cannot be found'
+          message: 'The requested resource cannot be found',
+          statusCode: 404,
         }
       ];
-    
+
     newIncident['statusId'] = 2;
 
     store.dispatch(actions.changeStatus(2,1));
@@ -174,13 +175,14 @@ describe('async actions', () => {
     const store = mockStore();
     const newIncident = testIncident;
     const expectedActions = [
-        { 
-          type: types.ERROR_ACTION, 
+        {
+          type: types.ERROR_ACTION,
           status: true,
-          message: 'You might not be logged in/authorized. Please try again.'
+          message: 'You might not be logged in/authorized. Please try again.',
+          statusCode: 401,
         }
       ];
-    
+
     newIncident['statusId'] = 2;
 
     store.dispatch(actions.changeStatus(2,1));

--- a/mock_endpoints/auth.js
+++ b/mock_endpoints/auth.js
@@ -1,6 +1,6 @@
 const auth = (req, res, next) => {
   const token = req.query.token || req.headers['authorization'];
-  if (token == 'false') {
+  if (token == 'null' || token == 'false') {
     res.status(401).send({
       error: true,
       message: 'Sorry. You might not be authorized.',

--- a/src/Components/CustomMenu/CustomMenu.Component.jsx
+++ b/src/Components/CustomMenu/CustomMenu.Component.jsx
@@ -24,12 +24,12 @@ export class CustomMenu extends React.Component {
   };
 
   render() {
-    const styles = { fontSize: '0.75vw', backgroundColor: '#ffffff', width: '9.5vw', height: '5vh' };
+    const styles = { fontSize: '0.75vw', backgroundColor: '#ffffff', width: '9.7vw', height: '5vh' };
     return (
       <SelectField
         underlineStyle={{ display: 'none' }}
-        iconStyle={{ fill: '#000000', marginRight: '1rem', textAlign: 'center' }}
-        labelStyle={{ textAlign: 'center', marginLeft: '1.85rem' }}
+        iconStyle={{ fill: '#000000', marginRight: '1vw', textAlign: 'center' }}
+        labelStyle={{ textAlign: 'center', marginLeft: '1.85vw' }}
         value={this.state.value}
         onChange={this.handleChange}
         className="custom-menu"

--- a/src/Components/IncidentFilter/IncidentFilter.Component.jsx
+++ b/src/Components/IncidentFilter/IncidentFilter.Component.jsx
@@ -66,7 +66,7 @@ export default class IncidentFilter extends Component {
       trackSwitched: {
         backgroundColor: '#81D4FA'
       },
-      selectField: { fontSize: '0.75vw', backgroundColor: '#ffffff', width: '9.5vw', height: '5vh' }
+      selectField: { fontSize: '0.75vw', backgroundColor: '#ffffff', width: '9.7vw', height: '5vh' }
     };
     return (
       <div className="filters-container">
@@ -89,8 +89,8 @@ export default class IncidentFilter extends Component {
 
           <SelectField
             underlineStyle={{ display: 'none' }}
-            iconStyle={{ fill: '#000000', marginRight: '1rem', textAlign: 'center' }}
-            labelStyle={{ textAlign: 'center', marginLeft: '1.85rem' }}
+            iconStyle={{ fill: '#000000', marginRight: '1vw', textAlign: 'center' }}
+            labelStyle={{ textAlign: 'center', marginLeft: '1.85vw' }}
             value={this.state.flagFilterValue}
             onChange={this.handleFlagChange}
             className="flag-filter"
@@ -104,8 +104,8 @@ export default class IncidentFilter extends Component {
 
           <SelectField
             underlineStyle={{ display: 'none' }}
-            iconStyle={{ fill: '#000000', marginRight: '1rem', textAlign: 'center' }}
-            labelStyle={{ textAlign: 'center', marginLeft: '1.85rem' }}
+            iconStyle={{ fill: '#000000', marginRight: '1vw', textAlign: 'center' }}
+            labelStyle={{ textAlign: 'center', marginLeft: '1.85vw' }}
             value={this.state.incidentsType}
             onChange={this.handleTypeChange}
             className="incidents-filter"

--- a/src/Components/IncidentFilter/IncidentFilter.scss
+++ b/src/Components/IncidentFilter/IncidentFilter.scss
@@ -61,7 +61,7 @@
       height: 5vh;
       min-height: 2.5rem;
       width: 17vw;
-      margin: 0 1rem;
+      margin: 0 1vw;
       margin-right: 5px;
       border-radius: 4px;
       background-color: #ffffff;
@@ -72,7 +72,7 @@
         min-height: 2.3rem;
         width: 4.2vw;
         border-radius: 4px;
-        margin: 0.2rem 0.3rem;
+        margin: 0.2vw 0.3vw;
         font-family: 'DIN Pro';
         font-size: 0.75vw;
         text-align: center;
@@ -87,7 +87,7 @@
     }
 
     .flag-filter, .incidents-filter, .custom-menu {
-      margin: 0 0.5rem;
+      margin: 0 0.5vw;
       min-height: 2.5rem !important;
       border-radius: 4px;
       box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);

--- a/src/Components/PrivateRoute/PrivateRoute.Component.jsx
+++ b/src/Components/PrivateRoute/PrivateRoute.Component.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Route, Redirect } from 'react-router-dom';
 
@@ -10,11 +11,13 @@ import authenticateUser from '../../helpers/auth';
  */
 const PrivateRoute = ({ component: Component, ...rest }) => {
   authenticateUser.authenticate();
+  const { statusCode } = rest;
+  const loginErrors = [401, 403];
   return (
     <Route
       {...rest}
       render={props =>
-        authenticateUser.isAuthenticated ? (
+        authenticateUser.isAuthenticated && loginErrors.indexOf(statusCode) == -1 ? (
           <Component {...props} />
         ) : (
           <Redirect to={{ pathname: '/login', state: { from: props.location } }} />
@@ -29,7 +32,19 @@ const PrivateRoute = ({ component: Component, ...rest }) => {
  */
 PrivateRoute.propTypes = {
   component: PropTypes.oneOfType([PropTypes.node, PropTypes.func]), // Container || functional react component
-  location: PropTypes.object
+  location: PropTypes.object,
+  statusCode: PropTypes.number
 };
 
-export default PrivateRoute;
+/**
+ * map state from the store to props
+ * @param {*} state
+ * @returns {*} partial state
+ */
+const mapStateToProps = state => {
+  return {
+    statusCode: state.error.statusCode
+  };
+};
+
+export default connect(mapStateToProps)(PrivateRoute);

--- a/src/actions/errorAction.jsx
+++ b/src/actions/errorAction.jsx
@@ -16,6 +16,7 @@ export const errorAction = error => {
   return {
     type: ERROR_ACTION,
     status: true,
+    statusCode: error.response.status,
     message: `${message}`
   };
 };

--- a/src/helpers/auth.js
+++ b/src/helpers/auth.js
@@ -12,7 +12,6 @@ const authenticateUser = {
   authenticate() {
     if (this.validateUser()) {
       this.isAuthenticated = true;
-      return this.isAuthenticated;
     }
   },
   revokeAuthentication() {

--- a/src/pages/Login/LoginPage.Component.jsx
+++ b/src/pages/Login/LoginPage.Component.jsx
@@ -23,7 +23,7 @@ import config from '../../config';
  * LoginPage class
  */
 class LoginPage extends React.Component {
-  componentWillMount() {
+  componentDidMount() {
     authenticateUser.authenticate();
     let email = localStorage.getItem('email');
     if (email) {
@@ -44,6 +44,11 @@ class LoginPage extends React.Component {
     setReferrerInlocationStorage(from.pathname);
     const referrer = getReferrerInlocationStorage();
     const { isLoading, isError, errorMessage, hasToken } = this.props;
+
+    if (isError) {
+      authenticateUser.removeToken();
+      localStorage.clear();
+    }
 
     if (authenticateUser.isAuthenticated && hasToken) {
       return <Redirect to={(from.pathname = referrer)} />;

--- a/src/reducers/errorReducer.jsx
+++ b/src/reducers/errorReducer.jsx
@@ -12,30 +12,35 @@ const errorReducer = (state = initialState.error, action) => {
     case ERROR_ACTION:
       return {
         status: action.status,
+        statusCode: action.statusCode,
         message: action.message
       };
 
     case FETCH_INCIDENTS_SUCCESS:
       return {
         status: action.isError,
+        statusCode: null,
         message: ''
       };
 
     case FETCH_INCIDENT:
       return {
         status: action.isError,
+        statusCode: null,
         message: ''
       };
 
     case FETCH_STAFF:
       return {
         status: action.isError,
+        statusCode: null,
         message: ''
       };
 
     case GET_TOKEN_SUCCESS:
       return {
         status: action.isError,
+        statusCode: null,
         message: ''
       };
 

--- a/src/reducers/initialState.jsx
+++ b/src/reducers/initialState.jsx
@@ -4,6 +4,7 @@ export default {
   hasToken: false,
   error: {
     status: false,
+    statusCode: null,
     message: ''
   },
   selectedIncident: {


### PR DESCRIPTION
#### What does this PR do?
- Currently, if a user is authenticated in another andela app, they can
  visit /dashboard without being redirected to /login for proper auth.
- Although they do not see any incidents if they lack a valid token from
  the API, /dashboard needs to be protected.
#### Where should the reviewer start?
View file changes in PR
#### How should this be manually tested?
- Fire up the app on localhost. This is best tested with the actual api. Run it as well, and in the `.env` file, change the `API_URL` to `http://localhost:3000/api`
- While authenticated in another andela app, say `ais`, attempt to visit
  /dashboard
- You should be redirected to /login if you're not a registered user.