### PR TITLE
feat: Add a filter by assignees

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-NODE_ENV=staging
-API_URL=https://api-staging-wire.andela.com
+NODE_ENV=development
+API_URL=http://localhost:3000/api
 ANDELA_API_BASE_URL=https://api-prod.andela.com
-BASE_URL=https://staging-wire.andela.com
+BASE_URL=http://wire.andela.com:8080

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-NODE_ENV=development
-API_URL=http://localhost:3000/api
+NODE_ENV=staging
+API_URL=https://api-staging-wire.andela.com
 ANDELA_API_BASE_URL=https://api-prod.andela.com
-BASE_URL=http://wire.andela.com:8080
+BASE_URL=https://staging-wire.andela.com

--- a/__tests__/Dashboard.test.jsx
+++ b/__tests__/Dashboard.test.jsx
@@ -30,7 +30,9 @@ describe('Dashboard', () => {
         location={{}}
         history={{}}
         incidents={[]}
+        staff={[]}
         loadIncidents={() => {}}
+        fetchStaff={() => {}}
         isLoading={false}
         isError={false}
         errorMessage={''}
@@ -52,7 +54,9 @@ describe('Dashboard', () => {
         location={{}}
         history={{}}
         incidents={[]}
+        staff={[]}
         loadIncidents={() => {}}
+        fetchStaff={() => {}}
         isLoading
         isError={false}
         errorMessage={''}
@@ -77,7 +81,9 @@ describe('Dashboard', () => {
         location={{}}
         history={{}}
         incidents={[]}
+        staff={[]}
         loadIncidents={() => {}}
+        fetchStaff={() => {}}
         isLoading={false}
         isError
         errorMessage={'Fake test error'}
@@ -107,7 +113,9 @@ describe('Filter functionality', () => {
         location={{}}
         history={{}}
         incidents={[]}
+        staff={[]}
         loadIncidents={mockLoadIncidents}
+        fetchStaff={() => {}}
         isLoading={false}
         isError={false}
         errorMessage={''}
@@ -127,7 +135,8 @@ describe('Filter functionality', () => {
     });
 
     dashboard.setState({
-      typeFilter: 'All Incidents'
+      typeFilter: 'All Incidents',
+      assignedToMe: false
     });
 
     expect(dashboard.find('.incidents-progress').exists()).toEqual(true);

--- a/__tests__/IncidentFilter.test.jsx
+++ b/__tests__/IncidentFilter.test.jsx
@@ -6,7 +6,7 @@ import IncidentFilter from '../src/Components/IncidentFilter/IncidentFilter.Comp
 
 describe('IncidentFilter component', () => {
   it('should have all the IncidentFilter content', () => {
-    const incidentFilter = shallow(<IncidentFilter />);
+    const incidentFilter = shallow(<IncidentFilter  staff={[]} />);
     const tree = shallowToJSON(incidentFilter);
     expect(tree.props.className).toEqual('filters-container');
     expect(tree.type).toEqual('div');

--- a/mock_endpoints/helpers.js
+++ b/mock_endpoints/helpers.js
@@ -1,9 +1,11 @@
 const getUserName = email => {
-  let username = {};
-  const [firstName, lastName] = email.split('@')[0].split('.');
-  const first = firstName[0].toUpperCase() + firstName.substr(1, firstName.length);
-  const last = lastName[0].toUpperCase() + lastName.substr(1, lastName.length);
-  username = `${first} ${last}`;
+  let username = email.split('@')[0];
+  if (username.includes('.')) {
+    const [firstName, lastName] = username.split('.');
+    const first = firstName[0].toUpperCase() + firstName.substr(1, firstName.length);
+    const last = lastName[0].toUpperCase() + lastName.substr(1, lastName.length);
+    username = `${first} ${last}`;
+  }
   return username;
 };
 

--- a/mock_endpoints/mockMiddleware.js
+++ b/mock_endpoints/mockMiddleware.js
@@ -124,6 +124,10 @@ module.exports = {
   addUser: (req, res) => {
     setTimeout(() => {
       let { email, roleId, locationId } = req.body;
+      let andelaEmailRegex =  /@andela.com$/;
+      if(!andelaEmailRegex.test(email)) {
+        return res.status(500).send({ error: true, message: 'Please use Andela emails only', status: 'error' });
+      }
       res.send({ data: addUser(email, roleId, locationId), status: 'success' });
     }, 2000);
   },

--- a/src/Components/IncidentFilter/IncidentFilter.Component.jsx
+++ b/src/Components/IncidentFilter/IncidentFilter.Component.jsx
@@ -10,6 +10,9 @@ import './IncidentFilter.scss';
 //Components
 import CustomMenu from '../CustomMenu/CustomMenu.Component';
 
+// helpers
+import authenticateUser from '../../helpers/auth';
+
 /**
  * @class IncidentFilter
  */
@@ -19,8 +22,9 @@ export default class IncidentFilter extends Component {
     this.state = {
       durationFilterValue: 0,
       flagFilterValue: 'All Incidents',
+      assigneesFilter: 'All Assignees',
       incidentsType: 'Pending',
-      assignedToMe: false
+      assignedToMe: !authenticateUser.isAdmin()
     };
   }
 
@@ -52,7 +56,14 @@ export default class IncidentFilter extends Component {
     this.setState({ assignedToMe: !this.state.assignedToMe });
   };
 
+  handleAssigneesFilter = (event, index, value) => {
+    this.props.filterByAssignee(value);
+    this.setState({ assigneesFilter: value });
+  };
+
   render() {
+    const { staff } = this.props;
+    const assignees = staff.filter(user => user.hasOwnProperty('assignedRole'));
     const styles = {
       thumbOff: {
         backgroundColor: '#616161'
@@ -79,11 +90,29 @@ export default class IncidentFilter extends Component {
             trackSwitchedStyle={styles.trackSwitched}
             onToggle={() => this.handleMineAllChange()}
             toggled={!this.state.assignedToMe}
+            disabled={!authenticateUser.isAdmin()}
           />
           <span className="toggle-label">All</span>
         </div>
         <div className="filters">
           <span className="incidents-label">Incidents</span>
+
+          {authenticateUser.isAdmin() ? (
+            <SelectField
+              underlineStyle={{ display: 'none' }}
+              iconStyle={{ fill: '#000000', marginRight: '1vw', textAlign: 'center' }}
+              labelStyle={{ textAlign: 'center', marginLeft: '1.85vw' }}
+              value={this.state.assigneesFilter}
+              onChange={this.handleAssigneesFilter}
+              className="incidents-filter"
+              style={styles.selectField}
+            >
+              <MenuItem value={'All Assignees'} primaryText="All Assignees" />
+              {assignees.map((assignee, i) => {
+                return <MenuItem key={i} value={assignee.username} primaryText={assignee.username} />;
+              })}
+            </SelectField>
+          ) : null}
 
           <CustomMenu changeCountryFilter={this.props.changeCountryFilter} />
 
@@ -144,5 +173,7 @@ IncidentFilter.propTypes = {
   changeTime: PropTypes.func,
   changeMineAll: PropTypes.func,
   incident: PropTypes.object,
-  onSelectStatus: PropTypes.func
+  onSelectStatus: PropTypes.func,
+  staff: PropTypes.array,
+  filterByAssignee: PropTypes.func
 };

--- a/src/Components/TimelineSidebar/TimelineSidebar.Component.jsx
+++ b/src/Components/TimelineSidebar/TimelineSidebar.Component.jsx
@@ -10,6 +10,9 @@ import moment from 'moment';
 // styling
 import './TimelineSidebar.scss';
 
+// helpers
+import authenticateUser from '../../helpers/auth';
+
 // components
 import CustomButton from '../Button/Button.Component';
 
@@ -212,13 +215,19 @@ export default class TimelineSidebar extends Component {
                 value={assignee.id}
                 onChange={this.handleChangeAssignee}
                 className="dropdown dropdown-assigned"
+                disabled={!authenticateUser.isAdmin()}
               >
                 {staff.map((staffMember, i) => {
                   return <MenuItem key={i} value={staffMember.id} primaryText={staffMember.username} />;
                 })}
               </DropDownMenu>
             ) : (
-              <DropDownMenu value={0} onChange={this.handleChangeAssignee} className="dropdown dropdown-assigned">
+              <DropDownMenu
+                value={0}
+                onChange={this.handleChangeAssignee}
+                className="dropdown dropdown-assigned"
+                disabled={!authenticateUser.isAdmin()}
+              >
                 <MenuItem value={0} primaryText="Assign someone" />
                 {staff ? (
                   staff.map((staffMember, i) => {

--- a/src/pages/Login/LoginPage.Component.jsx
+++ b/src/pages/Login/LoginPage.Component.jsx
@@ -50,7 +50,7 @@ class LoginPage extends React.Component {
       localStorage.clear();
     }
 
-    if (authenticateUser.isAuthenticated && hasToken) {
+    if (authenticateUser.isAuthenticated && hasToken && !isError) {
       return <Redirect to={(from.pathname = referrer)} />;
     }
 


### PR DESCRIPTION
#### What does this PR do?
- Adds a dropdown with a list of assignees, so that incidents can be filtered by assignee.
- This only works for admins.
#### Description of Task to be completed?
Show a dropdown with a list of assignees, then incidents can be filtered by assignee.
Note: The above feature should only be visible to the admin
 - Assignees who are not admins can only see their own assigned incidents
 - Assignees cannot assign incidents(only admins can), but they can CC.
#### Where should the reviewer start?
View file changes on PR.
#### How should this be manually tested?
- Log in to wire on localhost as an admin. Assign or CC a few test users on a couple of incidents. You can now filter incidents by those assigned to a specific user. 
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#160442794](https://www.pivotaltracker.com/story/show/160442794)
#### Screenshots (if appropriate)
N/A
