### PR TITLE
#163751043 Fix bug accessing incidents page after login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-
+[![CircleCI](https://circleci.com/gh/AndelaOSP/wire/tree/develop.svg?style=svg)](https://circleci.com/gh/AndelaOSP/wire/tree/develop)
+[![Coverage Status](https://coveralls.io/repos/github/AndelaOSP/wire/badge.svg?branch=develop)](https://coveralls.io/github/AndelaOSP/wire?branch=develop)
 # WIRE
 
 WIRE - Workspace Incident Reporting platform

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@babel/runtime": "7.0.0-beta.46",
+        "@babel/runtime": "^7.3.1",
         "@material-ui/core": "^3.6.2",
         "axios": "^0.17.1",
         "body-parser": "^1.18.2",

--- a/src/Components/TimelineNotes/__snapshots__/TimelineNotes.test.js.snap
+++ b/src/Components/TimelineNotes/__snapshots__/TimelineNotes.test.js.snap
@@ -68,6 +68,7 @@ ShallowWrapper {
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
     "simulateError": [Function],
@@ -880,9 +881,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,

--- a/src/Components/TimelineSidebar/__snapshots__/TimelineSidebar.test.js.snap
+++ b/src/Components/TimelineSidebar/__snapshots__/TimelineSidebar.test.js.snap
@@ -253,6 +253,7 @@ ShallowWrapper {
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
     "simulateError": [Function],
@@ -8043,9 +8044,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,

--- a/src/Components/UserFilter/__snapshots__/Userfilter.test.jsx.snap
+++ b/src/Components/UserFilter/__snapshots__/Userfilter.test.jsx.snap
@@ -194,6 +194,7 @@ ShallowWrapper {
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
     "simulateError": [Function],
@@ -2524,9 +2525,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,

--- a/src/actions/errorAction.jsx
+++ b/src/actions/errorAction.jsx
@@ -9,7 +9,6 @@ const getErrorMessage = (error) => {
 export const errorAction = (error) => {
   if (error.response) {
     let message;
-
     switch (error.response.status) {
       case 401 || 403:
         message = getErrorMessage(error) || 'You might not be logged in/authorized. Please try again.';
@@ -26,9 +25,11 @@ export const errorAction = (error) => {
 
     return {
       type: ERROR_ACTION,
-      status: true,
-      statusCode: error.response.status,
-      message: `${message}`,
+      payload: {
+        status: true,
+        statusCode: error.response.status,
+        message: `${message}`,
+      },
     };
   }
 };

--- a/src/actions/errorAction.test.js
+++ b/src/actions/errorAction.test.js
@@ -32,9 +32,11 @@ describe('async actions', () => {
     const mockResponse = httpResponse(400, { message: 'The requested resource cannot be found' });
     const expectedActions = {
       type: ERROR_ACTION,
-      status: true,
-      statusCode: 400,
-      message: mockResponse.response.data.message,
+      payload: {
+        status: true,
+        statusCode: 400,
+        message: mockResponse.response.data.message,
+      },
     };
 
     expect(errorAction(mockResponse)).toEqual(expectedActions);

--- a/src/actions/http.jsx
+++ b/src/actions/http.jsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
+const token = localStorage.getItem('token');
 export const http = () => axios.create({
   baseURL: process.env.API_URL,
-  headers: { Authorization: localStorage.getItem('token') },
+  headers: { Authorization: token },
 });

--- a/src/actions/http.jsx
+++ b/src/actions/http.jsx
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
-const token = localStorage.getItem('token');
 export const http = () => axios.create({
   baseURL: process.env.API_URL,
-  headers: { Authorization: `Bearer ${token}` },
+  headers: { Authorization: localStorage.getItem('token') },
 });

--- a/src/actions/incidentAction.test.js
+++ b/src/actions/incidentAction.test.js
@@ -117,9 +117,11 @@ describe('async actions', () => {
     const expectedActions = [
       {
         type: ERROR_ACTION,
-        status: true,
-        statusCode: 404,
-        message: mockResponse.response.data.message,
+        payload: {
+          status: true,
+          statusCode: 404,
+          message: mockResponse.response.data.message,
+        },
       },
     ];
     moxios.wait(() => mockAxios(mockResponse, moxios, false));

--- a/src/actions/timelineAction.test.js
+++ b/src/actions/timelineAction.test.js
@@ -6,7 +6,7 @@ import {
   httpResponse,
   mockStore,
   mockAxios,
-  mockDispatchAction
+  mockDispatchAction,
 } from '../testHelpers';
 
 describe('async actions', () => {
@@ -18,82 +18,84 @@ describe('async actions', () => {
     moxios.uninstall();
   });
 
-  let updatedNote = notes[0];
-  updatedNote['note'] = 'A new note';
+  const updatedNote = notes[0];
+  updatedNote.note = 'A new note';
 
-  let incidentWithNewStatus = testIncidents[0];
-  incidentWithNewStatus['statusId'] = 2;
+  const incidentWithNewStatus = testIncidents[0];
+  incidentWithNewStatus.statusId = 2;
 
-  let incidentWithNewAssignee = testIncidents[0];
-  incidentWithNewAssignee['assigneeId'] = 1;
+  const incidentWithNewAssignee = testIncidents[0];
+  incidentWithNewAssignee.assigneeId = 1;
 
   const expectedActions = [
     {
       type: types.IS_LOADING,
-      status: true
+      status: true,
     },
     {
       type: types.FETCH_INCIDENT,
       incident: testIncidents[0],
       isLoading: false,
-      isError: false
+      isError: false,
     },
     {
       type: types.ADD_NOTE,
-      note: notes[0]
+      note: notes[0],
     },
     {
       type: types.EDIT_NOTE,
       note: updatedNote,
-      index: 0
+      index: 0,
     },
     {
       type: types.ARCHIVE_NOTE,
       note: notes[0],
-      index: 0
+      index: 0,
     },
     {
       type: types.CHANGE_STATUS,
-      incident: incidentWithNewStatus
+      incident: incidentWithNewStatus,
     },
     {
       type: types.CHANGE_ASSIGNEE,
-      incident: incidentWithNewAssignee
+      incident: incidentWithNewAssignee,
     },
     {
       type: types.ADD_CHAT,
-      chat: chats[2]
+      chat: chats[2],
     },
     {
       type: types.ERROR_ACTION,
-      status: true,
-      message: 'You might not be logged in/authorized. Please try again.',
-      statusCode: 401,
-    }
+      payload: {
+        status: true,
+        message: 'You might not be logged in/authorized. Please try again.',
+        statusCode: 401,
+      },
+    },
   ];
 
-  it('creates all appropriate actions when loading incident details', done => {
+  it('creates all appropriate actions when loading incident details', (done) => {
     const store = mockStore();
     store.dispatch(actions.loadIncidentDetails(testIncidents[0].id));
     moxios.wait(() => {
-      let incidentRequest = moxios.requests.at(0);
-      let notesRequest = moxios.requests.at(1);
-      let chatsRequest = moxios.requests.at(2);
+      const incidentRequest = moxios.requests.at(0);
+      const notesRequest = moxios.requests.at(1);
+      const chatsRequest = moxios.requests.at(2);
       incidentRequest.respondWith({
         status: 200,
         response: {
           status: 'success',
-          data: testIncidents[0]
-        }
+          data: testIncidents[0],
+        },
       });
       notesRequest.respondWith({
         status: 200,
         response: {
           status: 'success',
           data: {
-            notes
-          }
-        }
+            notes,
+          },
+        },
       });
       chatsRequest
         .respondWith({
@@ -101,9 +103,9 @@ describe('async actions', () => {
           response: {
             status: 'success',
             data: {
-              chats
-            }
-          }
+              chats,
+            },
+          },
         })
         .then(() => {
           const storeActions = store.getActions();
@@ -115,35 +117,37 @@ describe('async actions', () => {
   });
 
   it('creates all appropriate actions when adding a note', () => {
-    let noteText = notes[0].note;
-    let incidentId = notes[0].incidentId;
-    let userId = notes[0].userId;
+    const noteText = notes[0].note;
+    const incidentId = notes[0].incidentId;
+    const userId = notes[0].userId;
 
     const mockResponse = httpResponse(201, { data: notes[0] });
     const store = mockStore();
     moxios.wait(() => mockAxios(mockResponse, moxios));
 
-    return mockDispatchAction(store, actions.addNote(noteText, incidentId, userId), [expectedActions[2]]);
+    return mockDispatchAction(store, actions.addNote(noteText, incidentId, userId),
+      [expectedActions[2]]);
   });
 
   it('creates all appropriate actions when editing a note', () => {
-    let noteText = 'A new note';
-    let noteId = notes[0].id;
-    let index = 0;
+    const noteText = 'A new note';
+    const noteId = notes[0].id;
+    const index = 0;
 
-    let updatedNote = notes[0];
-    updatedNote['note'] = noteText;
+    const updatedNote = notes[0];
+    updatedNote.note = noteText;
 
     const mockResponse = httpResponse(200, { data: updatedNote });
     const store = mockStore();
     moxios.wait(() => mockAxios(mockResponse, moxios));
 
-    return mockDispatchAction(store, actions.editNote(noteText, noteId, index), [expectedActions[3]]);
+    return mockDispatchAction(store, actions.editNote(noteText, noteId, index),
+      [expectedActions[3]]);
   });
 
   it('creates all appropriate actions when archiving a note', () => {
-    let noteId = notes[0].id;
-    let index = 0;
+    const noteId = notes[0].id;
+    const index = 0;
 
     const mockResponse = httpResponse(200, { data: notes[0] });
     const store = mockStore();
@@ -153,52 +157,56 @@ describe('async actions', () => {
   });
 
   it('creates all appropriate actions when changing incident status', () => {
-    let incidentId = testIncidents[0].id;
-    let statusId = 2;
-    let incidentWithNewStatus = testIncidents[0];
-    incidentWithNewStatus['statusId'] = 2;
+    const incidentId = testIncidents[0].id;
+    const statusId = 2;
+    const incidentWithNewStatus = testIncidents[0];
+    incidentWithNewStatus.statusId = 2;
 
     const mockResponse = httpResponse(200, { data: incidentWithNewStatus });
     const store = mockStore();
     moxios.wait(() => mockAxios(mockResponse, moxios));
 
-    return mockDispatchAction(store, actions.changeStatus(statusId, incidentId), [expectedActions[5]]);
+    return mockDispatchAction(store, actions.changeStatus(statusId, incidentId),
+      [expectedActions[5]]);
   });
 
   it('creates all appropriate actions when changing incident assignee', () => {
-    let incidentId = testIncidents[0].id;
-    let assigneeId = 1;
-    let incidentWithNewAssignee = testIncidents[0];
-    incidentWithNewAssignee['assigneeId'] = assigneeId;
+    const incidentId = testIncidents[0].id;
+    const assigneeId = 1;
+    const incidentWithNewAssignee = testIncidents[0];
+    incidentWithNewAssignee.assigneeId = assigneeId;
 
     const mockResponse = httpResponse(200, { data: incidentWithNewAssignee });
     const store = mockStore();
     moxios.wait(() => mockAxios(mockResponse, moxios));
 
-    return mockDispatchAction(store, actions.changeAssignee(assigneeId, incidentId), [expectedActions[6]]);
+    return mockDispatchAction(store, actions.changeAssignee(assigneeId, incidentId),
+      [expectedActions[6]]);
   });
 
   it('creates all appropriate actions when sending messages', () => {
-    let incidentId = testIncidents[0].id;
-    let userId = 3;
-    let message = chats[2].chat;
+    const incidentId = testIncidents[0].id;
+    const userId = 3;
+    const message = chats[2].chat;
 
     const mockResponse = httpResponse(200, { data: chats[2] });
     const store = mockStore();
     moxios.wait(() => mockAxios(mockResponse, moxios));
 
-    return mockDispatchAction(store, actions.sendMessage(incidentId, userId, message), [expectedActions[7]]);
+    return mockDispatchAction(store, actions.sendMessage(incidentId, userId, message),
+      [expectedActions[7]]);
   });
 
   it('dispatches error action when there is an error with a request', () => {
-    let incidentId = testIncidents[0].id;
-    let userId = 3;
-    let message = chats[2].chat;
+    const incidentId = testIncidents[0].id;
+    const userId = 3;
+    const message = chats[2].chat;
 
     const mockResponse = httpResponse(401, { message: 'You might not be logged in/authorized. Please try again.' });
     const store = mockStore();
     moxios.wait(() => mockAxios(mockResponse, moxios, false));
 
-    return mockDispatchAction(store, actions.sendMessage(incidentId, userId, message), [expectedActions[8]]);
+    return mockDispatchAction(store, actions.sendMessage(incidentId, userId, message),
+      [expectedActions[8]]);
   });
 });

--- a/src/pages/AdminDashboard/__snapshots__/AdminDashboardComponent.test.js.snap
+++ b/src/pages/AdminDashboard/__snapshots__/AdminDashboardComponent.test.js.snap
@@ -264,6 +264,7 @@ ShallowWrapper {
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
     "simulateError": [Function],
@@ -3752,9 +3753,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,

--- a/src/pages/Dashboard/__snapshots__/Dashboard.test.js.snap
+++ b/src/pages/Dashboard/__snapshots__/Dashboard.test.js.snap
@@ -133,6 +133,7 @@ ShallowWrapper {
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
     "simulateError": [Function],
@@ -913,9 +914,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,

--- a/src/pages/IncidentTimeline/__snapshots__/IncidentTimeline.test.js.snap
+++ b/src/pages/IncidentTimeline/__snapshots__/IncidentTimeline.test.js.snap
@@ -281,6 +281,7 @@ ShallowWrapper {
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
     "simulateError": [Function],
@@ -6683,9 +6684,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,

--- a/src/pages/Login/LoginPage.Component.jsx
+++ b/src/pages/Login/LoginPage.Component.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
 import RaisedButton from 'material-ui/RaisedButton';
 import CustomNotification from '../../Components/CustomNotification/CustomNotification.Component';
-import CircularProgressIndicator from '../../Components/Progress/Progress.Component';
 import { getToken } from '../../actions/tokenAction';
 import './LoginPage.scss';
 import authenticateUser from '../../helpers/auth';
@@ -48,9 +47,8 @@ export class LoginPage extends React.Component {
     setReferrerInlocationStorage(from.pathname);
     const referrer = getReferrerInlocationStorage();
     const {
-      isLoading, isError, errorMessage, hasToken,
+      isError, errorMessage, hasToken,
     } = this.props;
-
     if (isError) {
       authenticateUser.removeToken();
       localStorage.clear();
@@ -59,48 +57,43 @@ export class LoginPage extends React.Component {
     if (authenticateUser.isAuthenticated && hasToken) {
       return <Redirect to={(from.pathname = referrer)} />;
     }
-
     return (
       <div>
-        {isLoading ? (
-          <CircularProgressIndicator />
-        ) : (
-          <div className="login-page">
-            <div className="left-container">
-              <div>
-                <img className="andela-logo" src="/assets/images/andelaLogo.png" />
-              </div>
-              <div className="welcome-text">
-                <p>
+        <div className="login-page">
+          <div className="left-container">
+            <div>
+              <img className="andela-logo" src="/assets/images/andelaLogo.png" />
+            </div>
+            <div className="welcome-text">
+              <p>
                   Welcome to
-                  {' '}
-                  <span className="wire">Wire </span>
-                  <br />
+                {' '}
+                <span className="wire">Wire </span>
+                <br />
                   Please sign in with your Google account to proceed
-                </p>
-              </div>
-              <RaisedButton
-                className="button"
-                icon={<img className="google-logo" src="../../../assets/images/icons8-google.svg" />}
-                href={`${config.ANDELA_API_BASE_URL}/login?redirect_url=${config.BASE_URL}/login`}
-                label={<p className="label">Sign In With Google</p>}
-                style={styles.button}
-              />
+              </p>
             </div>
-            <div className="right-container">
-              <img className="landing-image" src="/assets/images/wire_landing_page_vector@2x.png" />
-              <div className="right-text">
-                <p>
-                  <span style={{ fontWeight: 600 }}>An Incident</span>
-                  {' '}
-                  <br />
-Reporting Platform
-                </p>
-              </div>
-              <div className="underline" />
-            </div>
+            <RaisedButton
+              className="button"
+              icon={<img className="google-logo" src="../../../assets/images/icons8-google.svg" />}
+              href={`${config.ANDELA_API_BASE_URL}/login?redirect_url=${config.BASE_URL}/login`}
+              label={<p className="label">Sign In With Google</p>}
+              style={styles.button}
+            />
           </div>
-        )}
+          <div className="right-container">
+            <img className="landing-image" src="/assets/images/wire_landing_page_vector@2x.png" />
+            <div className="right-text">
+              <p>
+                <span style={{ fontWeight: 600 }}>An Incident</span>
+                {' '}
+                <br />
+                Reporting Platform
+              </p>
+            </div>
+            <div className="underline" />
+          </div>
+        </div>
         {isError ? (
           <CustomNotification type="error" message={errorMessage} autoHideDuration={150000} open />
         ) : (
@@ -117,7 +110,6 @@ Reporting Platform
 LoginPage.propTypes = {
   location: PropTypes.object,
   getToken: PropTypes.func,
-  isLoading: PropTypes.bool,
   isError: PropTypes.bool,
   hasToken: PropTypes.bool,
   errorMessage: PropTypes.string,
@@ -126,14 +118,12 @@ LoginPage.propTypes = {
 LoginPage.defaultProps = {
   location: {},
   getToken: () => {},
-  isLoading: false,
   isError: false,
   hasToken: false,
   errorMessage: '',
 };
 
 const mapStateToProps = state => ({
-  isLoading: state.isLoading,
   hasToken: state.hasToken,
   isError: state.error.status,
   errorMessage: state.error.message,

--- a/src/pages/Search/__snapshots__/SearchComponent.test.js.snap
+++ b/src/pages/Search/__snapshots__/SearchComponent.test.js.snap
@@ -133,6 +133,7 @@ ShallowWrapper {
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
     "simulateError": [Function],
@@ -201,9 +202,9 @@ ShallowWrapper {
             incidentDescription="Some random thing happened and I didnt like it"
             incidentFlag="Red"
             incidentId="cjezu2kr700010wx1yy6kxu5z"
-            incidentReportDate="reported on Feb 2, 2018"
+            incidentReportDate="reported on 2 Feb 2018"
             incidentSubject="Theft"
-            incidentTime="03:00:00"
+            incidentTime="3:00:00 AM"
           />
           <IncidentCard
             assignees={
@@ -233,9 +234,9 @@ ShallowWrapper {
             incidentDescription="Some other random thing happened and I hated it"
             incidentFlag="Yellow"
             incidentId="cjezu2kr700010wx1yy6kxu5y"
-            incidentReportDate="reported on Feb 2, 2018"
+            incidentReportDate="reported on 2 Feb 2018"
             incidentSubject="Fighting"
-            incidentTime="03:00:00"
+            incidentTime="3:00:00 AM"
           />
         </div>,
       ],
@@ -316,9 +317,9 @@ ShallowWrapper {
               incidentDescription="Some random thing happened and I didnt like it"
               incidentFlag="Red"
               incidentId="cjezu2kr700010wx1yy6kxu5z"
-              incidentReportDate="reported on Feb 2, 2018"
+              incidentReportDate="reported on 2 Feb 2018"
               incidentSubject="Theft"
-              incidentTime="03:00:00"
+              incidentTime="3:00:00 AM"
             />,
             <IncidentCard
               assignees={
@@ -348,9 +349,9 @@ ShallowWrapper {
               incidentDescription="Some other random thing happened and I hated it"
               incidentFlag="Yellow"
               incidentId="cjezu2kr700010wx1yy6kxu5y"
-              incidentReportDate="reported on Feb 2, 2018"
+              incidentReportDate="reported on 2 Feb 2018"
               incidentSubject="Fighting"
-              incidentTime="03:00:00"
+              incidentTime="3:00:00 AM"
             />,
           ],
           "className": "incident-cards",
@@ -387,9 +388,9 @@ ShallowWrapper {
               "incidentDescription": "Some random thing happened and I didnt like it",
               "incidentFlag": "Red",
               "incidentId": "cjezu2kr700010wx1yy6kxu5z",
-              "incidentReportDate": "reported on Feb 2, 2018",
+              "incidentReportDate": "reported on 2 Feb 2018",
               "incidentSubject": "Theft",
-              "incidentTime": "03:00:00",
+              "incidentTime": "3:00:00 AM",
             },
             "ref": null,
             "rendered": null,
@@ -425,9 +426,9 @@ ShallowWrapper {
               "incidentDescription": "Some other random thing happened and I hated it",
               "incidentFlag": "Yellow",
               "incidentId": "cjezu2kr700010wx1yy6kxu5y",
-              "incidentReportDate": "reported on Feb 2, 2018",
+              "incidentReportDate": "reported on 2 Feb 2018",
               "incidentSubject": "Fighting",
-              "incidentTime": "03:00:00",
+              "incidentTime": "3:00:00 AM",
             },
             "ref": null,
             "rendered": null,
@@ -502,9 +503,9 @@ ShallowWrapper {
               incidentDescription="Some random thing happened and I didnt like it"
               incidentFlag="Red"
               incidentId="cjezu2kr700010wx1yy6kxu5z"
-              incidentReportDate="reported on Feb 2, 2018"
+              incidentReportDate="reported on 2 Feb 2018"
               incidentSubject="Theft"
-              incidentTime="03:00:00"
+              incidentTime="3:00:00 AM"
             />
             <IncidentCard
               assignees={
@@ -534,9 +535,9 @@ ShallowWrapper {
               incidentDescription="Some other random thing happened and I hated it"
               incidentFlag="Yellow"
               incidentId="cjezu2kr700010wx1yy6kxu5y"
-              incidentReportDate="reported on Feb 2, 2018"
+              incidentReportDate="reported on 2 Feb 2018"
               incidentSubject="Fighting"
-              incidentTime="03:00:00"
+              incidentTime="3:00:00 AM"
             />
           </div>,
         ],
@@ -617,9 +618,9 @@ ShallowWrapper {
                 incidentDescription="Some random thing happened and I didnt like it"
                 incidentFlag="Red"
                 incidentId="cjezu2kr700010wx1yy6kxu5z"
-                incidentReportDate="reported on Feb 2, 2018"
+                incidentReportDate="reported on 2 Feb 2018"
                 incidentSubject="Theft"
-                incidentTime="03:00:00"
+                incidentTime="3:00:00 AM"
               />,
               <IncidentCard
                 assignees={
@@ -649,9 +650,9 @@ ShallowWrapper {
                 incidentDescription="Some other random thing happened and I hated it"
                 incidentFlag="Yellow"
                 incidentId="cjezu2kr700010wx1yy6kxu5y"
-                incidentReportDate="reported on Feb 2, 2018"
+                incidentReportDate="reported on 2 Feb 2018"
                 incidentSubject="Fighting"
-                incidentTime="03:00:00"
+                incidentTime="3:00:00 AM"
               />,
             ],
             "className": "incident-cards",
@@ -688,9 +689,9 @@ ShallowWrapper {
                 "incidentDescription": "Some random thing happened and I didnt like it",
                 "incidentFlag": "Red",
                 "incidentId": "cjezu2kr700010wx1yy6kxu5z",
-                "incidentReportDate": "reported on Feb 2, 2018",
+                "incidentReportDate": "reported on 2 Feb 2018",
                 "incidentSubject": "Theft",
-                "incidentTime": "03:00:00",
+                "incidentTime": "3:00:00 AM",
               },
               "ref": null,
               "rendered": null,
@@ -726,9 +727,9 @@ ShallowWrapper {
                 "incidentDescription": "Some other random thing happened and I hated it",
                 "incidentFlag": "Yellow",
                 "incidentId": "cjezu2kr700010wx1yy6kxu5y",
-                "incidentReportDate": "reported on Feb 2, 2018",
+                "incidentReportDate": "reported on 2 Feb 2018",
                 "incidentSubject": "Fighting",
-                "incidentTime": "03:00:00",
+                "incidentTime": "3:00:00 AM",
               },
               "ref": null,
               "rendered": null,
@@ -745,9 +746,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,

--- a/src/reducers/incidentReducer.jsx
+++ b/src/reducers/incidentReducer.jsx
@@ -5,13 +5,8 @@ const incidentReducer = (state = initialState.incidents, action) => {
   switch (action.type) {
     case FETCH_INCIDENTS_SUCCESS:
       return action.incidents;
-
     case SEARCH_INCIDENTS:
       return action.incidents;
-
-    case CHANGE_STATUS:
-      return state;
-
     default:
       return state;
   }

--- a/src/reducers/loadingReducer.jsx
+++ b/src/reducers/loadingReducer.jsx
@@ -8,7 +8,7 @@ import {
   GET_TOKEN_SUCCESS,
 } from '../actions/actionTypes';
 
-const loadingReducer = (state = initialState.isLoading, action) => {
+const loadingReducer = (state = initialState, action) => {
   switch (action.type) {
     case IS_LOADING:
       return action.status;
@@ -26,7 +26,7 @@ const loadingReducer = (state = initialState.isLoading, action) => {
       return action.isLoading;
 
     case ERROR_ACTION:
-      return !action.status;
+      return !action.payload.status;
 
     default:
       return state;

--- a/src/reducers/loadingReducer.jsx
+++ b/src/reducers/loadingReducer.jsx
@@ -8,7 +8,7 @@ import {
   GET_TOKEN_SUCCESS,
 } from '../actions/actionTypes';
 
-const loadingReducer = (state = initialState, action) => {
+const loadingReducer = (state = initialState.isLoading, action) => {
   switch (action.type) {
     case IS_LOADING:
       return action.status;

--- a/src/testHelpers.jsx
+++ b/src/testHelpers.jsx
@@ -34,9 +34,11 @@ export const expectedActionFailure = (errorMessage, statusCode) => ([
   isLoading,
   {
     type: ERROR_ACTION,
-    status: true,
-    statusCode,
-    message: errorMessage,
+    payload: {
+      status: true,
+      statusCode,
+      message: errorMessage,
+    },
   },
 ]);
 


### PR DESCRIPTION
#### What does this PR do?
Fixes the bug which rendered a blank page if there is an error after logging in

#### Description of Task to be completed?
- remove a loader on the landing page
- change the ERROR_ACTION action creator to only return type and payload
- change the Authorisation header format to exclude word `Bearer`
- Update affected unit tests
- update the version of `@babel/runtime` on `package.json` from beta to `7.3.1`

#### Where should the reviewer start?
- Re-installing the node modules
- ensure your email address is added to the api database table: `users`

#### How should this be manually tested?
- fetch the branch using `git fetch` then `git checkout bg-fix-logging-feature-163751043` to checkout to the branch
- start the `api server`
- ensure your  `.env` variables are up to date
- run `yarn start` and open the application on port `8080` or otherwise stated in your `.env` file
- Once on the landing page, click on `SIGN IN WITH GOOGLE` and use your Andela email address
- You should be directed to incidents page whether or not there were errors fetching from the api.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
- [#163751043](https://www.pivotaltracker.com/story/show/163751043)

#### Screenshots (if appropriate)
N/A
