### PR TITLE
#164005006: Fixes breaking stylings on timelines page

### DIFF
--- a/src/Components/TimelineSidebar/TimelineSidebar.scss
+++ b/src/Components/TimelineSidebar/TimelineSidebar.scss
@@ -49,7 +49,6 @@
     .incident-description {
       margin-top: 2rem;
       width: 100%;
-      height: 100%;
       border-radius: 5px;
       background-color: #ffffff;
       .description-details {


### PR DESCRIPTION
#### What does this PR do?
- Fixes a breaking styling on the `timelines` page.

#### How should this be manually tested?
- Visit  the `timelines/[id]` page, the design should be fixed.

#### What are the relevant pivotal tracker stories?
[#164005006](https://www.pivotaltracker.com/story/show/164005006)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/8231705/52856436-748df980-3135-11e9-932c-4594d1227410.png)

<img width="369" alt="image" src="https://user-images.githubusercontent.com/8231705/52856446-7e176180-3135-11e9-8111-491d41d1a900.png">

