### PR TITLE
(feature): redesign the timelines page

### DIFF
--- a/src/Components/TimelineNotes/TimelineNotes.Component.jsx
+++ b/src/Components/TimelineNotes/TimelineNotes.Component.jsx
@@ -5,6 +5,7 @@ import TextField from 'material-ui/TextField';
 import ModeEdit from 'material-ui/svg-icons/editor/mode-edit';
 import Archive from 'material-ui/svg-icons/content/archive';
 import Dialog from 'material-ui/Dialog';
+import Toggle from 'material-ui/Toggle';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import './TimelineNotes.scss';
@@ -19,6 +20,7 @@ export default class TimelineNotes extends Component {
       content: '',
       note: {},
       index: null,
+      myNotes: true,
     };
   }
 
@@ -66,6 +68,16 @@ export default class TimelineNotes extends Component {
     this.props.editNote(this.state.note.note, this.state.note.id, this.state.index);
   };
 
+  handleMineAllNotesChange = () => {
+    this.setState({ myNotes: !this.state.myNotes });
+  }
+
+  filterMyNotes = (notes) => {
+    const myEmail = localStorage.getItem('email');
+    const myNotes = notes.filter(note => note.userEmail === myEmail);
+    return myNotes;
+  }
+
   handleDateString = date => moment(date).format('MMM Do YYYY [at] h:mm a');
 
   render() {
@@ -78,11 +90,42 @@ export default class TimelineNotes extends Component {
       <CustomButton key={4} label="Submit" onClick={this.handleEditNote} />,
     ];
     const { notes } = this.props.incident;
+    const incidentNotes = (this.state.myNotes) ? notes : this.filterMyNotes(notes)
+
     return (
       <div className="notes-container">
         <List className="notes-list">
-          {notes.length > 0 ? (
-            notes.map((note, i) => (
+          <div className="toggle-notes">
+            <span className={ !this.state.myNotes ? 'toggle-label mine' : 'toggle-label' }>Mine</span>
+            <Toggle
+              thumbSwitchedStyle={{ backgroundColor: 'yellow' }}
+              labelStyle={{ color: 'red' }}
+              thumbStyle={{
+                backgroundColor: '#1273bc',
+                top: '0px',
+                width: '25px',
+                height: '25px',
+              }}
+              thumbSwitchedStyle={{
+                width: '25px',
+                height: '25px',
+                backgroundColor: '#1273bc',
+              }}
+              trackStyle={{
+                overflow: 'hidden',
+                width: '60px',
+                backgroundColor: 'transparent',
+                border: '1px solid #1273bc',
+              }}
+              trackSwitchedStyle={{ backgroundColor: 'rgba(18, 115, 188, 0.5)' }}
+              style={{ width: '50px' }}
+              onToggle={this.handleMineAllNotesChange}
+              toggled={this.state.myNotes}
+            />
+            <span className={!this.state.myNotes ? 'toggle-label' : 'toggle-label all'}>All Notes</span>
+          </div>
+          {incidentNotes.length > 0 ? (
+            incidentNotes.map((note, i) => (
               <ListItem className="notes-list-item" key={i} disabled>
                 <div className="single-note-container">
                   <div className="note-header">

--- a/src/Components/TimelineNotes/TimelineNotes.Component.jsx
+++ b/src/Components/TimelineNotes/TimelineNotes.Component.jsx
@@ -90,118 +90,123 @@ export default class TimelineNotes extends Component {
       <CustomButton key={4} label="Submit" onClick={this.handleEditNote} />,
     ];
     const { notes } = this.props.incident;
-    const incidentNotes = (this.state.myNotes) ? notes : this.filterMyNotes(notes)
+    const incidentNotes = (this.state.myNotes) ? notes : this.filterMyNotes(notes);
 
     return (
-      <div className="notes-container">
-        <List className="notes-list">
-          <div className="toggle-notes">
-            <span className={ !this.state.myNotes ? 'toggle-label mine' : 'toggle-label' }>Mine</span>
-            <Toggle
-              thumbSwitchedStyle={{ backgroundColor: 'yellow' }}
-              labelStyle={{ color: 'red' }}
-              thumbStyle={{
-                backgroundColor: '#1273bc',
-                top: '0px',
-                width: '25px',
-                height: '25px',
-              }}
-              thumbSwitchedStyle={{
-                width: '25px',
-                height: '25px',
-                backgroundColor: '#1273bc',
-              }}
-              trackStyle={{
-                overflow: 'hidden',
-                width: '60px',
-                backgroundColor: 'transparent',
-                border: '1px solid #1273bc',
-              }}
-              trackSwitchedStyle={{ backgroundColor: 'rgba(18, 115, 188, 0.5)' }}
-              style={{ width: '50px' }}
-              onToggle={this.handleMineAllNotesChange}
-              toggled={this.state.myNotes}
-            />
-            <span className={!this.state.myNotes ? 'toggle-label' : 'toggle-label all'}>All Notes</span>
-          </div>
-          {incidentNotes.length > 0 ? (
-            incidentNotes.map((note, i) => (
-              <ListItem className="notes-list-item" key={i} disabled>
-                <div className="single-note-container">
-                  <div className="note-header">
-                    <span className="timestamp">
-                      {' '}
-                      {this.handleDateString(note.createdAt)}
-                      {' '}
-                    </span>
-                  </div>
-                  <Divider className="note-divider" />
-                  <div className="note-container">
-                    <div className="note-content">
-                      <p>{note.note}</p>
+      <div>
+        <div className='notes-toggle'>
+          <span className={!this.state.myNotes ? 'toggle-label mine' : 'toggle-label'}>Mine</span>
+          <Toggle
+            thumbSwitchedStyle={{ backgroundColor: 'yellow' }}
+            labelStyle={{ color: 'red' }}
+            thumbStyle={{
+              backgroundColor: '#1273bc',
+              top: '0px',
+              width: '25px',
+              height: '25px',
+            }}
+            thumbSwitchedStyle={{
+              width: '25px',
+              height: '25px',
+              backgroundColor: '#1273bc',
+            }}
+            trackStyle={{
+              overflow: 'hidden',
+              width: '60px',
+              backgroundColor: 'transparent',
+              border: '1px solid #1273bc',
+            }}
+            trackSwitchedStyle={{ backgroundColor: 'rgba(18, 115, 188, 0.5)' }}
+            style={{ width: '50px' }}
+            onToggle={this.handleMineAllNotesChange}
+            toggled={this.state.myNotes}
+          />
+          <span className={!this.state.myNotes ? 'toggle-label' : 'toggle-label all'}>All Notes</span>
+        </div>
+        <div className="notes-container">
+          <List className="notes-list">
+            <div className="toggle-notes">
+
+            </div>
+            {incidentNotes.length > 0 ? (
+              incidentNotes.map((note, i) => (
+                <ListItem className="notes-list-item" key={i} disabled>
+                  <div className="single-note-container">
+                    <div className="note-header">
+                      <span className="timestamp">
+                        {' '}
+                        {this.handleDateString(note.createdAt)}
+                        {' '}
+                      </span>
+                    </div>
+                    <Divider className="note-divider" />
+                    <div className="note-container">
+                      <div className="note-content">
+                        <p>{note.note}</p>
+                      </div>
+                    </div>
+                    <div className="note-actions">
+                      <ModeEdit className="note-action-edit" onClick={this.handleOpenEditDialog.bind(null, note, i)} />
+                      <Archive
+                          className="note-action-archive"
+                          onClick={this.handleOpenArchiveDialog.bind(null, note, i)}
+                        />
                     </div>
                   </div>
-                  <div className="note-actions">
-                    <ModeEdit className="note-action-edit" onClick={this.handleOpenEditDialog.bind(null, note, i)} />
-                    <Archive
-                        className="note-action-archive"
-                        onClick={this.handleOpenArchiveDialog.bind(null, note, i)}
-                      />
-                  </div>
-                </div>
-              </ListItem>
-            ))
-          ) : (
-            <div className="no-message">
-              <p>No Notes Created</p>
+                </ListItem>
+              ))
+            ) : (
+              <div className="no-message">
+                <p>No Notes Created</p>
+              </div>
+            )}
+          </List>
+
+          <div className="message-container">
+            <img src="/assets/images/clip.svg" color="red" className="notification-icon" />
+            <div className="message-input">
+              <form onSubmit={this.handleAddNote}>
+                <TextField
+                  value={this.state.content}
+                  onChange={this.handleChange}
+                  hintText="Add a note"
+                  ref="noteInput"
+                  underlineShow={false}
+                  className="text-input"
+                />
+              </form>
             </div>
-          )}
-        </List>
+            <div className="message-icon">
+              <img src="/assets/images/smile.svg" className="message-icon" />
+            </div>
+          </div>
 
-        <div className="message-container">
-          <img src="/assets/images/clip.svg" color="red" className="notification-icon" />
-          <div className="message-input">
-            <form onSubmit={this.handleAddNote}>
-              <TextField
-                value={this.state.content}
-                onChange={this.handleChange}
-                hintText="Add a note"
-                ref="noteInput"
-                underlineShow={false}
-                className="text-input"
-              />
-            </form>
-          </div>
-          <div className="message-icon">
-            <img src="/assets/images/smile.svg" className="message-icon" />
-          </div>
+          <Dialog
+            actions={archiveActions}
+            modal={false}
+            open={this.state.showArchiveDialog}
+            onRequestClose={this.handleCloseArchiveDialog}
+          >
+            Are you sure you want to archive this note?
+          </Dialog>
+
+          <Dialog
+            title="Edit note"
+            actions={editActions}
+            modal={false}
+            open={this.state.showEditDialog}
+            onRequestClose={this.handleCloseEditDialog}
+          >
+            <TextField
+              value={this.state.note.note}
+              onChange={this.handleEditNoteChange}
+              fullWidth
+              multiLine
+              rows={3}
+              ref="notesTextField"
+            />
+          </Dialog>
         </div>
-
-        <Dialog
-          actions={archiveActions}
-          modal={false}
-          open={this.state.showArchiveDialog}
-          onRequestClose={this.handleCloseArchiveDialog}
-        >
-          Are you sure you want to archive this note?
-        </Dialog>
-
-        <Dialog
-          title="Edit note"
-          actions={editActions}
-          modal={false}
-          open={this.state.showEditDialog}
-          onRequestClose={this.handleCloseEditDialog}
-        >
-          <TextField
-            value={this.state.note.note}
-            onChange={this.handleEditNoteChange}
-            fullWidth
-            multiLine
-            rows={3}
-            ref="notesTextField"
-          />
-        </Dialog>
       </div>
     );
   }

--- a/src/Components/TimelineNotes/TimelineNotes.Component.jsx
+++ b/src/Components/TimelineNotes/TimelineNotes.Component.jsx
@@ -105,9 +105,9 @@ export default class TimelineNotes extends Component {
               width: '25px',
               height: '25px',
             }}
-            thumbSwitchedStyle={{
-              backgroundColor: '#1273bc',
-            }}
+            thumbSwitchedStyle={{ // eslint-disable-line
+              backgroundColor: '#1273bc', // eslint-disable-line
+            }} // eslint-disable-line
             trackStyle={{
               overflow: 'hidden',
               width: '60px',

--- a/src/Components/TimelineNotes/TimelineNotes.Component.jsx
+++ b/src/Components/TimelineNotes/TimelineNotes.Component.jsx
@@ -106,8 +106,6 @@ export default class TimelineNotes extends Component {
               height: '25px',
             }}
             thumbSwitchedStyle={{
-              width: '25px',
-              height: '25px',
               backgroundColor: '#1273bc',
             }}
             trackStyle={{

--- a/src/Components/TimelineNotes/TimelineNotes.Component.jsx
+++ b/src/Components/TimelineNotes/TimelineNotes.Component.jsx
@@ -94,7 +94,7 @@ export default class TimelineNotes extends Component {
 
     return (
       <div>
-        <div className='notes-toggle'>
+        <div className="notes-toggle">
           <span className={!this.state.myNotes ? 'toggle-label mine' : 'toggle-label'}>Mine</span>
           <Toggle
             thumbSwitchedStyle={{ backgroundColor: 'yellow' }}
@@ -125,9 +125,6 @@ export default class TimelineNotes extends Component {
         </div>
         <div className="notes-container">
           <List className="notes-list">
-            <div className="toggle-notes">
-
-            </div>
             {incidentNotes.length > 0 ? (
               incidentNotes.map((note, i) => (
                 <ListItem className="notes-list-item" key={i} disabled>

--- a/src/Components/TimelineNotes/TimelineNotes.scss
+++ b/src/Components/TimelineNotes/TimelineNotes.scss
@@ -10,6 +10,37 @@
       padding-left: 0 !important;
       font-weight: 900 !important;
     }
+    .toggle-notes{
+      display: flex;
+      width: 200px;
+      color: #9ca4ab;
+      justify-content: space-between;
+
+      input{
+        width: 70px;
+        left: -5px;
+      }
+
+      div:nth-child(1){
+        width: 50px;
+        left: -15px;
+      }
+
+      span.toggle-label.mine, span.toggle-label.all{
+        color: #1273bc !important;
+      }
+
+      div:nth-child(2) {
+        div:nth-child(1){
+          div:nth-child(2){
+            div:nth-child(1){
+              background: purple;
+              width: auto !important;
+            }
+          }
+        }
+      }
+    }
     .notes-list-item {
       &>div {
         &>div {

--- a/src/Components/TimelineNotes/TimelineNotes.scss
+++ b/src/Components/TimelineNotes/TimelineNotes.scss
@@ -1,4 +1,39 @@
 @import "../../theme";
+
+.notes-toggle{
+  display: flex;
+  width: 200px;
+  color: #9ca4ab;
+  justify-content: space-between;
+  margin-right: 12vw;
+  margin-left: auto;
+  padding: 20px 0px;
+
+  input{
+    width: 70px;
+    left: -5px;
+  }
+
+  div:nth-child(1){
+    width: 50px;
+    left: -15px;
+  }
+
+  span.toggle-label.mine, span.toggle-label.all{
+    color: #1273bc !important;
+  }
+
+  div:nth-child(2) {
+    div:nth-child(1){
+      div:nth-child(2){
+        div:nth-child(1){
+          background: purple;
+          width: auto !important;
+        }
+      }
+    }
+  }
+}
 .notes-container {
   height: 83vh !important;
   overflow: scroll;
@@ -9,37 +44,6 @@
     .subheader {
       padding-left: 0 !important;
       font-weight: 900 !important;
-    }
-    .toggle-notes{
-      display: flex;
-      width: 200px;
-      color: #9ca4ab;
-      justify-content: space-between;
-
-      input{
-        width: 70px;
-        left: -5px;
-      }
-
-      div:nth-child(1){
-        width: 50px;
-        left: -15px;
-      }
-
-      span.toggle-label.mine, span.toggle-label.all{
-        color: #1273bc !important;
-      }
-
-      div:nth-child(2) {
-        div:nth-child(1){
-          div:nth-child(2){
-            div:nth-child(1){
-              background: purple;
-              width: auto !important;
-            }
-          }
-        }
-      }
     }
     .notes-list-item {
       &>div {

--- a/src/Components/TimelineNotes/TimelineNotes.test.js
+++ b/src/Components/TimelineNotes/TimelineNotes.test.js
@@ -11,6 +11,7 @@ describe('Timeline Notes component', () => {
     addNote: jest.fn(),
     editNote: jest.fn(),
     archiveNote: jest.fn(),
+    myNotes: true,
   };
 
   beforeEach(() => {
@@ -80,7 +81,7 @@ describe('Timeline Notes component', () => {
     wrapperInstance.handleArchiveNote({
       preventDefault: jest.fn(),
     });
-    
+
     expect(props.archiveNote).toHaveBeenLastCalledWith('2', 2);
     expect(wrapperInstance.state.showArchiveDialog).toBeFalsy();
   });
@@ -92,10 +93,10 @@ describe('Timeline Notes component', () => {
         value: 'Note',
       },
     });
-    
+
     expect(wrapperInstance.state.content).toEqual('Note');
   });
-  
+
   it('should initiate addNote action when handleAddNote method is called', () => {
     wrapper.setState({
       content: 'Some notes',
@@ -157,4 +158,10 @@ describe('Timeline Notes component', () => {
 
     expect(wrapper.find('ListItem').length).toEqual(1);
   });
+
+  it('should make modification to state when handleMineAllNotesChange is called', () =>{
+    expect(wrapperInstance.state.myNotes).toEqual(true);
+    wrapperInstance.handleMineAllNotesChange();
+    expect(wrapperInstance.state.myNotes).toEqual(false);
+  })
 });


### PR DESCRIPTION


#### What does this PR do?
- Redesigns the `Timelines Page` to add a toggle between `my notes` and `all notes` .

#### Description of Task to be completed?
- On the Incident Timelines Page, while viewing the notes made on an incident.
- A user should be able to to `toggle` between `my notes`and `all notes`.

#### How should this be manually tested?
- Visit the `Timelines Page` of a single `incident`, in the main window, select the `Notes` Tab.
- While on the `Notes` Tab, toggle between `my notes` and `all notes`. 

#### What are the relevant pivotal tracker stories?
[#164041372](https://www.pivotaltracker.com/story/show/164041372)
#### Screenshots (if appropriate)
N/A

![ezgif com-gif-maker](https://user-images.githubusercontent.com/8231705/53181256-48c4b500-3608-11e9-84d3-92d89291a8d9.gif)
