### PR TITLE
#164328569  Remove white separator between the incident and witnesses

### DIFF
--- a/src/Components/TimelineSidebar/TimelineSidebar.Component.jsx
+++ b/src/Components/TimelineSidebar/TimelineSidebar.Component.jsx
@@ -194,8 +194,6 @@ on
           </div>
         </div>
 
-        <hr className="divider" />
-
         <div className="incident-status">
           <span> Witnesses: </span>
           <div className="list">
@@ -282,8 +280,6 @@ on
             )}
           </div>
         </div>
-
-        <hr className="divider" />
 
         <Dialog
           title="Resolve an incident"

--- a/src/Components/TimelineSidebar/TimelineSidebar.scss
+++ b/src/Components/TimelineSidebar/TimelineSidebar.scss
@@ -10,15 +10,7 @@
     0 0.4rem 1rem 0 rgba(0, 0, 0, 0.19);
   overflow: scroll;
   max-height: 88vh !important;
-  .divider {
-    background-color: map_get($white, 100);
-    color: map_get($white, 100);
-    width: 100%;
-    margin: 2rem auto;
-    border-style: solid;
-    border-radius: 0.1rem;
-    padding: 0.1rem;
-  }
+  
   .incident-details {
     padding-top: 0.5rem 0 0.5rem 0;
     .incident-subject {
@@ -75,6 +67,7 @@
   .incident-status {
     font-family: "DIN Pro Light";
     font-weight: 400;
+    margin-top:1em;
     .list {
       display: flex;
       flex-direction: row;


### PR DESCRIPTION
#### What does this PR do?
 Removes the white separator between the incident description and the witnesses sections 

#### What are the relevant pivotal tracker stories?
[#164328569](https://www.pivotaltracker.com/n/projects/2117172/stories/164328569)
![screenshot 2019-03-08 at 15 59 58](https://user-images.githubusercontent.com/28872296/54030072-81918c00-41bb-11e9-93c3-80fd450557f9.png)
