### PR TITLE
#164723747 Fix left panel height of incident page

### DIFF
--- a/src/Components/TimelineSidebar/TimelineSidebar.scss
+++ b/src/Components/TimelineSidebar/TimelineSidebar.scss
@@ -9,7 +9,6 @@
   box-shadow: 0 0.2rem 0.5rem 0 rgba(0, 0, 0, 0.2),
     0 0.4rem 1rem 0 rgba(0, 0, 0, 0.19);
   overflow: scroll;
-  max-height: 88vh !important;
   
   .incident-details {
     padding-top: 0.5rem 0 0.5rem 0;


### PR DESCRIPTION
#### What does this PR do?

Following responsiveness guidelines, this PR fixes the left panel of the incident page so that its height spans the height of the page instead.

#### Description of Task to be completed?

- Removes the `max-height` property causing the left panel of the to be limited to a certain height.

#### How should this be manually tested?
- Pull and checkout this branch
   ```bash
   git pull bg-fix-left-panel-height-164723747
    ```

   ```bash 
   git checkout bg-fix-left-panel-height-164723747 
   ```

- Navigate to Incidents page
- Scroll to the bottom of the page and
- Check that the left panel spans the height of the entire page

#### Any background context you want to provide?

N/A

#### What are the relevant pivotal tracker stories?

[#164723747](https://www.pivotaltracker.com/story/show/164723747)

#### Screenshots 
##### FORMER LOOK
![screencapture-wire-andela-8080-timeline-cjfkubrlv0002tgxs3mre-2019-03-19-10_14_21](https://user-images.githubusercontent.com/20358651/54593893-cf19be80-4a2f-11e9-8dd9-484bb5b513b0.png)

##### NEW LOOK
![screencapture-wire-andela-8080-timeline-cjfkubrlv0002tgxs3mre-2019-03-19-09_40_31](https://user-images.githubusercontent.com/20358651/54591745-31bc8b80-4a2b-11e9-93af-e6e387ca0323.png)