### PR TITLE
#164754585 Redesign archive noted confirmation dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
             "lcov",
             "text",
             "clover"
-          ],
+        ],
         "moduleNameMapper": {
             "^.+\\.(css|less|scss)$": "identity-obj-proxy"
         },

--- a/src/Components/TimelineNotes/TimelineNotes.Component.jsx
+++ b/src/Components/TimelineNotes/TimelineNotes.Component.jsx
@@ -1,10 +1,13 @@
 import React, { Component } from 'react';
 import { List, ListItem } from 'material-ui/List';
+import Button from '@material-ui/core/Button';
 import Divider from 'material-ui/Divider';
 import TextField from 'material-ui/TextField';
 import ModeEdit from 'material-ui/svg-icons/editor/mode-edit';
 import Archive from 'material-ui/svg-icons/content/archive';
-import Dialog from 'material-ui/Dialog';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContentText from '@material-ui/core/DialogContentText';
 import Toggle from 'material-ui/Toggle';
 import PropTypes from 'prop-types';
 import moment from 'moment';
@@ -81,10 +84,16 @@ export default class TimelineNotes extends Component {
   handleDateString = date => moment(date).format('MMM Do YYYY [at] h:mm a');
 
   render() {
-    const archiveActions = [
-      <CustomButton key={1} label="Cancel" onClick={this.handleCloseArchiveDialog} />,
-      <CustomButton key={2} label="Archive" onClick={this.handleArchiveNote} />,
-    ];
+    const styles = {
+      archiveButton: {
+        backgroundColor: '#1273bc',
+        color: '#ffffff',
+      },
+      dialogtext: {
+        paddingRight: '150px',
+        marginBottom: '20px',
+      },
+    };
     const editActions = [
       <CustomButton key={3} label="Cancel" onClick={this.handleCloseEditDialog} />,
       <CustomButton key={4} label="Submit" onClick={this.handleEditNote} />,
@@ -177,12 +186,29 @@ export default class TimelineNotes extends Component {
           </div>
 
           <Dialog
-            actions={archiveActions}
             modal={false}
             open={this.state.showArchiveDialog}
-            onRequestClose={this.handleCloseArchiveDialog}
+            onClose={this.handleCloseArchiveDialog}
+            PaperProps={
+              {
+                style:
+                  {
+                    paddingTop: '20px',
+                    paddingRight: '5px',
+                    paddingLeft: '20px',
+                  },
+              }
+            }
           >
-            Are you sure you want to archive this note?
+            <DialogContentText style={styles.dialogtext}>
+              Are you sure you want to archive this note?
+            </DialogContentText>
+            <DialogActions>
+              <div className="archive-note-dialog">
+                <Button size="small" onClick={this.handleCloseArchiveDialog}> Cancel </Button>
+                <Button variant="contained" style={styles.archiveButton} size="small" onClick={this.handleArchiveNote}> Archive </Button>
+              </div>
+            </DialogActions>
           </Dialog>
 
           <Dialog

--- a/src/Components/TimelineNotes/TimelineNotes.scss
+++ b/src/Components/TimelineNotes/TimelineNotes.scss
@@ -105,6 +105,9 @@
         }
       }
     }
+    .archive-button {
+      background-color: #1273bc !important;
+    }
     .no-message {
       width: 244.2px;
       height: 106px;


### PR DESCRIPTION
#### What does this PR do?
- Redesign the archive notes confirmation dialog to match design mock ups.

#### Description of Task to be completed?
- Redesign the archive notes confirmation dialog to match design mock ups.

#### How should this be manually tested?
- On the single incident page.
- Click on the archive note icon
- The redesigned archive note confirmation dialog will pop up

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#164754585](https://www.pivotaltracker.com/story/show/164754585)
#### Screenshots (if appropriate)

### Before:
<img width="1435" alt="Screenshot 2019-03-20 at 15 13 23" src="https://user-images.githubusercontent.com/8037062/54683598-146ae880-4b23-11e9-87be-83311264bd14.png">

### After
<img width="1440" alt="Screenshot 2019-03-20 at 15 12 47" src="https://user-images.githubusercontent.com/8037062/54683615-22206e00-4b23-11e9-94b6-bce344425d72.png">



