### PR TITLE
#164824525 Redesign the ccd section

### DIFF
--- a/src/Components/TimelineSidebar/TimelineSidebar.Component.jsx
+++ b/src/Components/TimelineSidebar/TimelineSidebar.Component.jsx
@@ -24,12 +24,12 @@ class TimelineSidebar extends Component {
       reportText: '',
     };
   }
-
+  
   /**
    * This lifecycle hook is used to update the list of ccd associates
    * on initial render
    */
-  componentWillMount() {
+  componentDidMount() {
     this.updateAssignee(this.props);
     this.updateCcdAssociates(this.props);
   }
@@ -155,6 +155,18 @@ class TimelineSidebar extends Component {
     return <img className="flag-image" src="/assets/images/yellow_flag.svg" alt="yellow" />;
   };
 
+  renderCCdImage =() => {
+    const { incident } = this.props;
+    const ccdAssociates = incident.assignees.filter(user => user.assignedRole === 'ccd');
+    return ccdAssociates.map(imageUrl => (
+      <img
+       className="cc-avatar" 
+       src={imageUrl.imageUrl} width="40px"
+       alt="Avatar"
+       height="40px" />
+    ));
+  }
+  
   render() {
     const { incident, staff } = this.props;
     const { assignee } = this.state;
@@ -265,6 +277,10 @@ on
             >
               {this.renderCC(staff, ccdAssociates)}
             </SelectField>
+          </div>
+
+          <div className="ccd-section">
+            {this.renderCCdImage()}
           </div>
 
           <span> Location: </span>

--- a/src/Components/TimelineSidebar/TimelineSidebar.scss
+++ b/src/Components/TimelineSidebar/TimelineSidebar.scss
@@ -142,4 +142,10 @@
       color: #000000;
     }
   }
+  .ccd-section{
+    .cc-avatar{
+      border-radius: 50%;
+      padding: 0.3125rem;
+    }
+  }
 }


### PR DESCRIPTION
#### What does this PR do?
Redesigns the CC'd section on the single incident page to have a search box and also match the mockups
#### Description of Task to be completed?
-  render ccd user's avatar
-  update the dropdown and use material-ui's `react-select`
#### How should this be manually tested?
- Navigate to the dashboard and click on an incident 
- Click on the 'CC:` section on the sidebar 
- Select  users to cc

#### What are the relevant pivotal tracker stories?
[#164824525](https://www.pivotaltracker.com/story/show/164824525)
#### Screenshots 
![Screenshot 2019-03-22 at 12 23 30](https://user-images.githubusercontent.com/28872296/54812924-60419d00-4c9d-11e9-9a69-63fc58439d1c.png)

