### PR TITLE
#160815524 Remove mine-all toggler for assignees

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -15,7 +15,7 @@ class LocalStorageMock {
   }
 
   setItem(key, val) {
-    return val || '';
+    this.store[key] = val || '';
   }
 
   clear() {

--- a/src/Components/IncidentFilter/IncidentFilter.Component.jsx
+++ b/src/Components/IncidentFilter/IncidentFilter.Component.jsx
@@ -10,6 +10,7 @@ import './IncidentFilter.scss';
 
 // Components
 import CustomMenu from '../CustomMenu/CustomMenu.Component';
+import { currentUser } from '../../helpers/decodeToken';
 
 /**
  * @class IncidentFilter
@@ -55,6 +56,7 @@ class IncidentFilter extends Component {
   };
 
   render() {
+    const userInfo = currentUser();
     const styles = {
       thumbOff: {
         backgroundColor: '#616161',
@@ -80,13 +82,17 @@ class IncidentFilter extends Component {
     return (
       <div className="filters-container">
         <div className="toggle-section">
-          <span className={`${this.state.assignedToMe ? 'toggle-label toggle-label--active' : 'toggle-label'}`}>Mine</span>
-          <Switch
-            color="default"
-            onChange={() => this.handleMineAllChange()}
-            checked={!this.state.assignedToMe}
-          />
-          <span className={`${!this.state.assignedToMe ? 'toggle-label toggle-label--active' : 'toggle-label'}`}>All incidents</span>
+          {userInfo.roleId === 3 ? (
+            <div>
+              <span className={`${this.state.assignedToMe ? 'toggle-label toggle-label--active' : 'toggle-label'}`}>Mine</span>
+              <Switch
+                color="default"
+                onChange={() => this.handleMineAllChange()}
+                checked={!this.state.assignedToMe}
+              />
+              <span className={`${!this.state.assignedToMe ? 'toggle-label toggle-label--active' : 'toggle-label'}`}>All incidents</span>
+            </div>
+          ) : ''}
         </div>
         <div className="filters">
           <span className="incidents-label">Incidents</span>

--- a/src/Components/IncidentFilter/IncidentFilter.test.js
+++ b/src/Components/IncidentFilter/IncidentFilter.test.js
@@ -60,7 +60,8 @@ describe('IncidentFilter component', () => {
     wrapper.instance().handleMineAllChange();
     expect(spied.calledOnce).toBeTruthy();
   });
-  it('should render Switch', () => {
+  it('should render Switch if user is admin', () => {
+    localStorage.setItem('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlSWQiOjMsImlhdCI6MTU1NDM3ODg3NywiZXhwIjoxNTU0NDY1Mjc3fQ.ErTZRWJAKOuJDJe0nFpcmjiSR5o7J0WFuXVBo8rHt28');
     wrapper = shallow(<IncidentFilter />);
     expect(wrapper.find('WithStyles(Switch)').length).toEqual(1);
   });
@@ -70,6 +71,11 @@ describe('IncidentFilter component', () => {
     const event = { target: { name: 'position ', value: 'new position' } };
     wrapper.find('WithStyles(Switch)').simulate('change', event);
     expect(spied.called).toEqual(true);
+  });
+  it('should not render Switch for assignee', () => {
+    localStorage.setItem('token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlSWQiOjIsImlhdCI6MTU1NDM3OTIzNSwiZXhwIjoxNTU0NDY1NjM1fQ.m1ly9LnbX0Ccu6mE7-Fb8BWRkYDkm7_ZzjWR6MaQzvg');
+    wrapper = shallow(<IncidentFilter />);
+    expect(wrapper.find('WithStyles(Switch)').length).toEqual(0);
   });
   it('should render Button', () => {
     wrapper = shallow(<IncidentFilter />);


### PR DESCRIPTION
#### What does this PR do?
- Remove the mine-all mine-all toggler for assignees.

#### Description of Task to be completed?
- Added logic to display mine-all toggler for admins and hide for assignees.
- Updated test suites.

#### How should this be manually tested?
- Start up the application.
- Log in as Admin, you should see the mine-all toggler. However, when you log in as an assignee, you won't see the mine-all toggler.

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[160815524](https://www.pivotaltracker.com/story/show/164793970)
#### Screenshots (if appropriate)
Admin
![image](https://user-images.githubusercontent.com/20397262/55399960-788aa500-5544-11e9-9bfa-5a2c8398ab3d.png)

Assignee
![image](https://user-images.githubusercontent.com/20397262/55399973-84766700-5544-11e9-95b9-e0af5b20a629.png)

