### PR TITLE
#164725031 Redesign note section to match mockup

### DIFF
--- a/src/Components/TimelineNotes/TimelineNotes.Component.jsx
+++ b/src/Components/TimelineNotes/TimelineNotes.Component.jsx
@@ -213,6 +213,7 @@ export default class TimelineNotes extends Component {
             ))
             }
           </List>
+          <div className="message-border" />
 
           <div className="message-container">
             <img src="/assets/images/clip.svg" color="red" className="attachment-icon" />
@@ -232,7 +233,7 @@ export default class TimelineNotes extends Component {
               <img src="/assets/images/smile.svg" className="message-icon" />
             </div>
             <div className="at-icon">@</div>
-            <button className="add-button">ADD</button>
+            <button className="add-button" onClick={this.handleAddNote}>ADD</button>
           </div>
 
           <Dialog

--- a/src/Components/TimelineNotes/TimelineNotes.Component.jsx
+++ b/src/Components/TimelineNotes/TimelineNotes.Component.jsx
@@ -81,7 +81,45 @@ export default class TimelineNotes extends Component {
     return myNotes;
   }
 
-  handleDateString = date => moment(date).format('MMM Do YYYY [at] h:mm a');
+  groupNotesByDate = (notes) => {
+    const dayNotes = notes.reduce((groupedNotes, note) => {
+      const date = note.createdAt.slice(0, 10);
+      if (!groupedNotes[date]) {
+        // eslint-disable-next-line no-param-reassign
+        groupedNotes[date] = { date: note.createdAt, notes: [note] };
+      } else {
+        groupedNotes[date].notes.push(note);
+      }
+      return groupedNotes;
+    }, {});
+
+    return dayNotes;
+  }
+
+  sortGroupedNotes = (notes) => {
+    const ordered = {};
+    Object.keys(notes).sort().forEach((key) => {
+      ordered[key] = notes[key];
+    });
+    return ordered;
+  }
+
+  handleDateString = (date) => {
+    let dateString = moment(date).format('LL');
+
+    const today = moment();
+    const yesterday = moment().subtract(1, 'day');
+
+    if (moment(date).isSame(today, 'day')) {
+      dateString = 'Today';
+    } else if (moment(date).isSame(yesterday, 'day')) {
+      dateString = 'Yesterday';
+    }
+
+    return dateString;
+  };
+
+  handleTimeString = date => moment(date).format('h:mm a');
 
   render() {
     const styles = {
@@ -98,8 +136,9 @@ export default class TimelineNotes extends Component {
       <CustomButton key={3} label="Cancel" onClick={this.handleCloseEditDialog} />,
       <CustomButton key={4} label="Submit" onClick={this.handleEditNote} />,
     ];
-    const { notes } = this.props.incident;
-    const incidentNotes = (this.state.myNotes) ? notes : this.filterMyNotes(notes);
+    const { notes: propNotes } = this.props.incident;
+    const incidentNotes = (this.state.myNotes) ? propNotes : this.filterMyNotes(propNotes);
+    const dayNotes = this.sortGroupedNotes(this.groupNotesByDate(incidentNotes));
 
     return (
       <div>
@@ -131,43 +170,52 @@ export default class TimelineNotes extends Component {
           <span className={!this.state.myNotes ? 'toggle-label' : 'toggle-label all'}>All Notes</span>
         </div>
         <div className="notes-container">
-          <List className="notes-list">
-            {incidentNotes.length > 0 ? (
-              incidentNotes.map((note, i) => (
-                <ListItem className="notes-list-item" key={i} disabled>
-                  <div className="single-note-container">
-                    <div className="note-header">
-                      <span className="timestamp">
-                        {' '}
-                        {this.handleDateString(note.createdAt)}
-                        {' '}
-                      </span>
-                    </div>
-                    <Divider className="note-divider" />
-                    <div className="note-container">
-                      <div className="note-content">
-                        <p>{note.note}</p>
+          <List>
+            {/* Iterate through the each day entry */}
+            {Object.entries(dayNotes).map(([, { date, notes }]) => (
+              <List className="notes-list">
+                {/* DATE */}
+                <div className="note-date">{this.handleDateString(date)}</div>
+                {notes.length > 0 ? (
+                  notes.map((note, i) => (
+                    <ListItem className="notes-list-item" key={i} disabled>
+                      <div className="single-note-container">
+                        <div className="note-header">
+                          <span className="timestamp">
+                            {' '}
+                            {this.handleTimeString(note.createdAt)}
+                            {' '}
+                          </span>
+                        </div>
+                        <Divider className="note-time-underline" />
+                        <div className="note-container">
+                          <div className="note-content">
+                            <p>{note.note}</p>
+                          </div>
+                        </div>
+                        <div className="note-actions">
+                          <ModeEdit className="note-action-edit" onClick={this.handleOpenEditDialog.bind(null, note, i)} />
+                          <Archive
+                            className="note-action-archive"
+                            onClick={this.handleOpenArchiveDialog.bind(null, note, i)}
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div className="note-actions">
-                      <ModeEdit className="note-action-edit" onClick={this.handleOpenEditDialog.bind(null, note, i)} />
-                      <Archive
-                          className="note-action-archive"
-                          onClick={this.handleOpenArchiveDialog.bind(null, note, i)}
-                        />
-                    </div>
+                    </ListItem>
+                  ))
+                ) : (
+                  <div className="no-message">
+                    <p>No Notes Created</p>
                   </div>
-                </ListItem>
-              ))
-            ) : (
-              <div className="no-message">
-                <p>No Notes Created</p>
-              </div>
-            )}
+                )}
+                <div className="note-divider" />
+              </List>
+            ))
+            }
           </List>
 
           <div className="message-container">
-            <img src="/assets/images/clip.svg" color="red" className="notification-icon" />
+            <img src="/assets/images/clip.svg" color="red" className="attachment-icon" />
             <div className="message-input">
               <form onSubmit={this.handleAddNote}>
                 <TextField
@@ -183,6 +231,8 @@ export default class TimelineNotes extends Component {
             <div className="message-icon">
               <img src="/assets/images/smile.svg" className="message-icon" />
             </div>
+            <div className="at-icon">@</div>
+            <button className="add-button">ADD</button>
           </div>
 
           <Dialog

--- a/src/Components/TimelineNotes/TimelineNotes.scss
+++ b/src/Components/TimelineNotes/TimelineNotes.scss
@@ -39,8 +39,9 @@
   height: 65vh !important;
   display: flex;
   justify-content: center;
+  flex-direction: column;
   overflow-y: scroll;
-  padding-bottom: 80px;
+
   .notes-list {
     width: 70vw;
     margin: 2rem auto;
@@ -91,7 +92,7 @@
             p {
               margin-top: 20px;
               font-family: 'DIN Pro' !important;
-              font-size: 11px;
+              font-size: 14px;
               line-height: 2.17;
               font-weight: 300;
               color: #000000;
@@ -116,6 +117,7 @@
       padding: 0 26px 0 26px !important;
       height: 1px;
       margin-left: 26px;
+      margin-right: 20px;
       background:
         repeating-linear-gradient(to right, rgba(0, 0, 0, 0.3) 0, rgba(0, 0, 0, 0.3) 5px, transparent 5px, transparent 12px)
     }
@@ -139,9 +141,9 @@
       }
     }
   }
+
   .message-container {
     position: fixed;
-    z-index: 2;
     bottom: 0px;
     display: flex;
     flex-direction: row;
@@ -151,31 +153,34 @@
     justify-content: space-between;
     align-items: center;
     padding-bottom: 50px;
+
     .attachment-icon {
       cursor: pointer;
-      margin-left: 15px;
-      margin-right: 15px;
+      margin-left: calc(31vw - 380px);
+      margin-right: 25px;
       margin-top: 15px;
       width: 24px;
       height: 24px;
       fill: rgba(0, 0, 0, 0.6) !important;
     }
+
     .message-input {
-      border-top: 1.6px solid black;
-      width: 70vw;
+      flex: 1 1 auto;
       height: 60px;
-      margin-left: calc(30vw - 380px);
+      max-width: 980px;
+      border-top: 1.6px solid black;
+
       .text-input {
-        width: 100% !important;
         text-align: center;
         padding-top: 15px;
+        width: 100% !important;
         input[type="text"] {
-          width: 100% !important;
           font-size: 18px !important;
         }
         align-items: center;
       }
     }
+
     .message-icon {
       cursor: pointer;
       height: 24px;
@@ -183,6 +188,7 @@
       margin-left: 5px;
       opacity: 0.7;
     }
+
     .at-icon {
       cursor: pointer;
       font-family: 'Source Sans Pro';
@@ -191,6 +197,7 @@
       margin-left: 15px;
       opacity: 0.6;
     }
+
     .add-button {
       cursor: pointer;
       margin-top: 15px;
@@ -200,6 +207,18 @@
       box-shadow: 1px 2px 3px 1px rgba(0, 0, 0, 0.1);
       border-radius: 8px;
       border-style: none;
+
+      &:hover {
+        transform: scale(1.1, 1.1);
+        background-color: #f5f5f5;
+      }
     }
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  .message-container .message-input {
+    // width: 50vw !important;
+    margin-left: 0 !important;
   }
 }

--- a/src/Components/TimelineNotes/TimelineNotes.scss
+++ b/src/Components/TimelineNotes/TimelineNotes.scss
@@ -1,5 +1,6 @@
 @import "../../theme";
-
+@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro);
+@import url(https://fonts.googleapis.com/css?family=Montserrat);
 .notes-toggle{
   display: flex;
   width: 200px;
@@ -35,17 +36,25 @@
   }
 }
 .notes-container {
-  height: 83vh !important;
-  overflow: scroll;
+  height: 65vh !important;
+  display: flex;
+  justify-content: center;
+  overflow-y: scroll;
+  padding-bottom: 80px;
   .notes-list {
-    overflow: scroll;
     width: 70vw;
     margin: 2rem auto;
+    max-width: 980px;
     .subheader {
       padding-left: 0 !important;
       font-weight: 900 !important;
     }
+    .note-date {
+      padding-left: 26px;
+      font-weight: 1000 !important;
+    }
     .notes-list-item {
+      padding: 16px 26px 0px 26px !important;
       &>div {
         &>div {
           padding: 0 !important;
@@ -60,31 +69,29 @@
           width: 202px;
           height: 22px;
           font-family: 'DIN Pro';
-          font-size: 17px;
-          font-weight: 500;
+          font-size: 14px;
+          font-weight: 900;
           font-style: normal;
           font-stretch: normal;
           line-height: 1.29;
           text-align: left;
           color: #000000;
         }
-        .note-divider {
+        .note-time-underline {
           width: 150px !important;
-          height: 6px !important;
-          background-color: #dff3fc !important;
+          height: 5px !important;
+          background-color: #F1F6F8 !important;
           border-radius: 5px !important;
         }
         .note-container {
           height: 100%;
           width: 100%;
           border-radius: 5px;
-          background-color: #f3f6f9;
           .note-content {
             p {
-              padding: 1rem;
-              text-transform: capitalize;
-              font-family: 'DIN Pro';
-              font-size: 12px;
+              margin-top: 20px;
+              font-family: 'DIN Pro' !important;
+              font-size: 11px;
               line-height: 2.17;
               font-weight: 300;
               color: #000000;
@@ -92,18 +99,25 @@
           }
         }
         .note-actions {
-          margin: 0.5rem;
+          margin-top: 0.7rem;
           padding: 1rem 0;
-          svg {
-            fill: #747474 !important;
-          }
           .note-action-edit,
           .note-action-archive {
-            padding: 0 0.25rem;
+            padding-right: 0.4rem;
             cursor: pointer;
+            fill: rgba(0, 0, 0, 0.4) !important;
+            height: 20px !important;
           }
         }
       }
+    }
+    .note-divider {
+      margin-top: 45px;
+      padding: 0 26px 0 26px !important;
+      height: 1px;
+      margin-left: 26px;
+      background:
+        repeating-linear-gradient(to right, rgba(0, 0, 0, 0.3) 0, rgba(0, 0, 0, 0.3) 5px, transparent 5px, transparent 12px)
     }
     .archive-button {
       background-color: #1273bc !important;
@@ -126,44 +140,66 @@
     }
   }
   .message-container {
-    top: auto !important;
-    bottom: 0 !important;
-    position: absolute !important;
-    .notification-icon {
+    position: fixed;
+    z-index: 2;
+    bottom: 0px;
+    display: flex;
+    flex-direction: row;
+    background-color: #fff;
+    width: 75vw;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 50px;
+    .attachment-icon {
       cursor: pointer;
-      margin-top: 1rem;
-      width: 30.4px;
-      height: 32.1px;
-      margin-left: 1rem;
-      position: absolute !important;
+      margin-left: 15px;
+      margin-right: 15px;
+      margin-top: 15px;
+      width: 24px;
+      height: 24px;
+      fill: rgba(0, 0, 0, 0.6) !important;
     }
     .message-input {
-      margin-left: 4rem;
+      border-top: 1.6px solid black;
       width: 70vw;
       height: 60px;
-      border-radius: 9px;
-      background-color: #F1F1F4;
+      margin-left: calc(30vw - 380px);
       .text-input {
-        border-top-color: map_get($grey, 700) !important;
         width: 100% !important;
         text-align: center;
-        padding: .3rem 0 0 1.5rem;
+        padding-top: 15px;
+        input[type="text"] {
+          width: 100% !important;
+          font-size: 18px !important;
+        }
         align-items: center;
       }
     }
     .message-icon {
-      cursor: pointer; // padding-right: 1rem;
-      width: 25.3px;
-      height: 25.3px;
-      position: absolute;
-      top: 10px;
-      right: 13px;
-      font-size: 25px;
       cursor: pointer;
+      height: 24px;
+      margin-top: 5px;
+      margin-left: 5px;
+      opacity: 0.7;
+    }
+    .at-icon {
+      cursor: pointer;
+      font-family: 'Source Sans Pro';
+      font-size: 24px;
+      margin-top: 15px;
+      margin-left: 15px;
       opacity: 0.6;
-      -webkit-transition: all ease-out 0.3s 0s;
-      -o-transition: all ease-out 0.3s 0s;
-      transition: all ease-out 0.3s 0s;
+    }
+    .add-button {
+      cursor: pointer;
+      margin-top: 15px;
+      margin-left: 25px;
+      width: 130px;
+      height: 40px;
+      box-shadow: 1px 2px 3px 1px rgba(0, 0, 0, 0.1);
+      border-radius: 8px;
+      border-style: none;
     }
   }
 }

--- a/src/Components/TimelineNotes/TimelineNotes.test.js
+++ b/src/Components/TimelineNotes/TimelineNotes.test.js
@@ -151,6 +151,7 @@ describe('Timeline Notes component', () => {
           {
             id: '1',
             note: 'some dummy notes',
+            createdAt: '2019-03-19 09:56:02.604+01',
           },
         ],
       },
@@ -159,9 +160,9 @@ describe('Timeline Notes component', () => {
     expect(wrapper.find('ListItem').length).toEqual(1);
   });
 
-  it('should make modification to state when handleMineAllNotesChange is called', () =>{
+  it('should make modification to state when handleMineAllNotesChange is called', () => {
     expect(wrapperInstance.state.myNotes).toEqual(true);
     wrapperInstance.handleMineAllNotesChange();
     expect(wrapperInstance.state.myNotes).toEqual(false);
-  })
+  });
 });

--- a/src/Components/TimelineNotes/TimelineNotes.test.js
+++ b/src/Components/TimelineNotes/TimelineNotes.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import { shallow } from 'enzyme';
 import TimelineNotes from './TimelineNotes.Component';
 import { testIncidents } from '../../../mock_endpoints/mockData';
@@ -144,20 +145,34 @@ describe('Timeline Notes component', () => {
   });
 
   it('should display a list of ListItem when an incident has notes', () => {
+    global.localStorage.setItem.email = 'steve.akinyemi@andela.com';
     wrapper.setProps({
       incident: {
         ...props.incident,
         notes: [
           {
             id: '1',
-            note: 'some dummy notes',
-            createdAt: '2019-03-19 09:56:02.604+01',
+            note: 'some dummy note',
+            createdAt: moment().format(),
+            userEmail: 'steve.akinyemi@andela.com',
+          },
+          {
+            id: '2',
+            note: 'another dummy note',
+            createdAt: moment().format(),
+            userEmail: 'steve.akinyemi@andela.com',
+          },
+          {
+            id: '3',
+            note: 'yet another dummy note',
+            createdAt: moment().subtract(1, 'day').format(),
+            userEmail: 'steve.akinyemi@andela.com',
           },
         ],
       },
     });
 
-    expect(wrapper.find('ListItem').length).toEqual(1);
+    expect(wrapper.find('ListItem').length).toEqual(3);
   });
 
   it('should make modification to state when handleMineAllNotesChange is called', () => {


### PR DESCRIPTION
#### What does this PR do?

This PR fixes the current design of the `notes` section to closely match what is provided in the [mockup](https://projects.invisionapp.com/share/ZVHNSBURQ2D#/screens/294058742) design.

#### Description of Task to be completed?

- Redesign notes
- Fix design of floating input box
- Implement grouping notes by dates
- Fix responsiveness of note section
- Add tests for added implementation

#### How should this be manually tested?
- Pull and checkout this branch
   ```bash
   git pull bg-redesign-note-section-to-match-mockup-164725031
    ```

   ```bash 
   git checkout bg-redesign-note-section-to-match-mockup-164725031 
   ```

- Navigate to Incidents page
- Review the note section

#### Any background context you want to provide?

N/A

#### What are the relevant pivotal tracker stories?

[#164725031](https://www.pivotaltracker.com/story/show/164725031)

#### Screenshots 
##### OLD LOOK
<img width="1680" alt="old-look" src="https://user-images.githubusercontent.com/20358651/55437350-94b73200-5596-11e9-8ddf-dc0a2454095a.png">

##### NEW LOOK
<img width="1680" alt="new-look" src="https://user-images.githubusercontent.com/20358651/55437361-9b45a980-5596-11e9-878c-361a6acee7f4.png">

##### MOCKUP
<img width="1680" alt="mock-up" src="https://user-images.githubusercontent.com/20358651/55437367-a0a2f400-5596-11e9-96ec-d134b712ef65.png">
