### PR TITLE
bg(page-refresh)fix-authenticated resources not displayed after login

### DIFF
--- a/src/actions/http.jsx
+++ b/src/actions/http.jsx
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
-const token = localStorage.getItem('token');
 export const http = () => axios.create({
   baseURL: process.env.API_URL,
-  headers: { Authorization: token },
+  headers: { Authorization: localStorage.getItem('token') },
 });


### PR DESCRIPTION
#### What does this PR do?

Fixes the issue with after login no resource which requires authentication to be viewed to be rendered for viewing till page refresh. For example, after login one is not able to see any incidents until the page is reloaded.

#### Description of Task to be completed?
Fix the bug such that once a user logs in, any part of the page they are should have various resources on the page for example incidents

#### How should this be manually tested?
Fire both the backend and front end applications and view the frontend on the local host on the port the frontend app is serving the pages
login (after successful login, incidents should appear on the page if any )
What are the relevant pivotal tracker stories?

[167131006](https://www.pivotaltracker.com/story/show/167131006)
#### Screenshots (if appropriate)
N/A
