### PR TITLE
#167161432 fix chat and notes input

### DIFF
--- a/src/Components/InputBox/InputBox.scss
+++ b/src/Components/InputBox/InputBox.scss
@@ -1,7 +1,7 @@
 @import "../../theme";
 
 .message-container {
-  position: fixed;
+  position: sticky;
   bottom: 0px;
   display: flex;
   flex-direction: row;

--- a/src/Components/TimelineNotes/TimelineNotes.scss
+++ b/src/Components/TimelineNotes/TimelineNotes.scss
@@ -38,7 +38,7 @@
 }
 
 .notes-container {
-  height: 65vh !important;
+  height: 75vh;
   display: flex;
   justify-content: center;
   flex-direction: column;
@@ -48,6 +48,7 @@
     width: 70vw;
     margin: 8rem auto;
     max-width: 980px;
+    margin-bottom: 7rem;
     .subheader {
       padding-left: 0 !important;
       font-weight: 900 !important;


### PR DESCRIPTION
#### What does this PR do?
Redesigns the reusable input for chat and notes to display the
relevant placeholder message for each tab.
#### Description of Task to be completed?
- Changed the positioning of the input so that each is visible when 
the user traverses to the relevant tab.
#### How should this be manually tested?
- Navigate to the dashboard
- Click on an incident
- Change back and forth between the notes and chat tab and notice the 
difference in the input
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#167161432](https://www.pivotaltracker.com/story/show/167161432)
#### Screenshots (if appropriate)
![Screen Recording 2019-07-12 at 10 12 37 2019-07-12 10_43_59](https://user-images.githubusercontent.com/30701246/61111335-02c29d80-a492-11e9-9d7d-17f1a966d464.gif)


