### PR TITLE
#167292973: modify chat section to stop scrolling from affecting the left panel

### DIFF
--- a/src/Components/TimelineChat/TimelineChat.scss
+++ b/src/Components/TimelineChat/TimelineChat.scss
@@ -1,7 +1,7 @@
 @import "../../theme";
 .chat-container {
   width: 100%;
-  height: 83vh !important;
+  height: 35vh;
   overflow: auto;
   .chat-list {
     overflow: scroll;

--- a/src/Components/TimelineNotes/TimelineNotes.scss
+++ b/src/Components/TimelineNotes/TimelineNotes.scss
@@ -165,7 +165,6 @@
     flex-direction: row;
     background-color: #fff;
     width: 75vw;
-    display: flex;
     justify-content: space-between;
     align-items: center;
     padding-bottom: 50px;

--- a/src/Components/TimelineSidebar/TimelineSidebar.scss
+++ b/src/Components/TimelineSidebar/TimelineSidebar.scss
@@ -8,8 +8,8 @@
   background-color: #f1f6f8;
   box-shadow: 0 0.2rem 0.5rem 0 rgba(0, 0, 0, 0.2),
     0 0.4rem 1rem 0 rgba(0, 0, 0, 0.19);
-  overflow: scroll;
-  
+  overflow: auto;
+  height: 100vh;
 
   .incident-status {
     font-family: "DIN Pro Light";

--- a/src/pages/IncidentTimeline/IncidentTimeline.scss
+++ b/src/pages/IncidentTimeline/IncidentTimeline.scss
@@ -15,6 +15,8 @@
     padding: 0 1rem;
     z-index: 0;
     position: relative;
+    height: auto;
+    overflow: auto;
     .chat-tab,
     .notes-tab {
       &>div {

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -26,6 +26,7 @@ body {
   margin: 0;
   box-sizing: border-box;
   background-color: #f1f6f8;
+  overflow: hidden;
 }
 
 $orange : (


### PR DESCRIPTION
#### What does this PR do?
modify the chat section to stop scrolling from affecting the left panel ie timeline sidebar.

#### Description of Task to be completed?
- set overflow style of the body to hidden to stop scrolling of the full page.
- set height of sidebar container to 100vh and overflow to auto.
- set timeline main content section to a height and overflow of auto.
- give the chat container height of 35vh.

#### How should this be manually tested?
- Clone this project
- checkout this branch `ft-chat-panel-scroll-167292973`
- Run the application.
- Log in to the application and select a single incident.
- Click on an incident of choice.
- Follow GIF(for after) below.

#### What are the relevant pivotal tracker stories?
[#167292973](https://www.pivotaltracker.com/story/show/167292973)
#### Screenshots (if appropriate)

#### Before:
![wire1](https://user-images.githubusercontent.com/40595048/61292246-6245e380-a7d9-11e9-8135-3640fc6d2179.gif)

#### After:
![afterWire](https://user-images.githubusercontent.com/40595048/61292257-68d45b00-a7d9-11e9-9614-57dd7194fced.gif)
