### PR TITLE
#165057910 View chats

### DIFF
--- a/src/Components/TimelineChat/TimelineChat.Component.jsx
+++ b/src/Components/TimelineChat/TimelineChat.Component.jsx
@@ -6,7 +6,6 @@ import moment from 'moment';
 import Chat from '../Chat/Chat.Component';
 import InputBox from '../InputBox/InputBox.Component';
 import './TimelineChat.scss';
-import { allChats } from '../../../mock_endpoints/mockData';
 
 class TimelineChat extends Component {
   constructor(props) {
@@ -14,6 +13,10 @@ class TimelineChat extends Component {
     this.state = {
       message: '',
     };
+  }
+
+  componentDidMount() {
+    this.props.getSlackchat();
   }
 
   handleChange = (e) => {
@@ -70,7 +73,7 @@ class TimelineChat extends Component {
   }
 
   render() {
-    const dayChats = this.sortGroupedChats(this.groupChatByDate(allChats));
+    const dayChats = this.sortGroupedChats(this.groupChatByDate(this.props.incident.chats));
     return (
       <div className="chat-container">
         {Object.entries(dayChats).map(([, { date, chats }]) => (
@@ -106,6 +109,7 @@ class TimelineChat extends Component {
 TimelineChat.propTypes = {
   incident: PropTypes.object.isRequired,
   sendMessage: PropTypes.func.isRequired,
+  getSlackchat: PropTypes.func.isRequired,
 };
 
 export default TimelineChat;

--- a/src/Components/TimelineChat/TimelineChat.test.jsx
+++ b/src/Components/TimelineChat/TimelineChat.test.jsx
@@ -1,15 +1,20 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import shallowToJSON from 'enzyme-to-json';
+import moment from 'moment';
 import TimelineChat from './TimelineChat.Component';
 import { testIncidents, allChats } from '../../../mock_endpoints/mockData';
 
 testIncidents[0].chats = allChats;
 
 describe('Timeline Chat component', () => {
+  const props = {
+    getSlackchat: jest.fn(),
+  };
+
   it('should have all the Timeline Chat content', () => {
     const timelineChat = shallow(
-      <TimelineChat incident={testIncidents[0]} sendMessage={() => {}} />,
+      <TimelineChat {...props} incident={testIncidents[0]} sendMessage={() => {}} />,
     );
     const tree = shallowToJSON(timelineChat);
     expect(shallowToJSON(tree)).toMatchSnapshot();
@@ -17,7 +22,7 @@ describe('Timeline Chat component', () => {
 
   it('should handle post message', () => {
     const timelineChat = shallow(
-      <TimelineChat incident={testIncidents[0]} sendMessage={() => {}} />,
+      <TimelineChat {...props} incident={testIncidents[0]} sendMessage={() => {}} />,
     );
     timelineChat.instance().refs = {
       messageInput: {
@@ -34,7 +39,7 @@ describe('Timeline Chat component', () => {
 
   it('should dispay all chats', () => {
     const timelineChat = shallow(
-      <TimelineChat incident={testIncidents[0]} sendMessage={() => {}} />,
+      <TimelineChat {...props} incident={testIncidents[0]} sendMessage={() => {}} />,
     );
     const chat = timelineChat.find('Chat');
     expect(chat.length).toEqual(4);
@@ -42,7 +47,7 @@ describe('Timeline Chat component', () => {
 
   it('should handle change', () => {
     const timelineChat = shallow(
-      <TimelineChat incident={testIncidents[0]} sendMessage={() => {}} />,
+      <TimelineChat {...props} incident={testIncidents[0]} sendMessage={() => {}} />,
     );
     timelineChat.instance().refs = {
       messageInput: {
@@ -53,5 +58,26 @@ describe('Timeline Chat component', () => {
     expect(textField.length).toEqual(1);
     textField.simulate('change', { preventDefault: jest.fn(), target: { value: 'hello' } });
     expect(timelineChat.state().message).toEqual('hello');
+  });
+
+  it('should handle date formating', () => {
+    const timelineChat = shallow(
+      <TimelineChat {...props} incident={testIncidents[0]} sendMessage={() => {}} />,
+    );
+    const expectedTimeFormat = moment('2019-03-08 15:54:51.71+01').format('[at] h:mm a');
+
+    expect(timelineChat.instance().handleDateString('2019-03-08 15:54:51.71+01'))
+      .toEqual(expectedTimeFormat);
+  });
+
+  it('should test date grouping function', () => {
+    const timelineChat = shallow(
+      <TimelineChat {...props} incident={testIncidents[0]} sendMessage={() => {}} />,
+    );
+    
+    expect(timelineChat.instance().groupedChatsDate(moment()))
+      .toEqual('Today');
+    expect(timelineChat.instance().groupedChatsDate(moment().subtract(1, 'days')))
+      .toEqual('Yesterday');
   });
 });

--- a/src/Components/TimelineSidebar/TimelineSidebar.test.js
+++ b/src/Components/TimelineSidebar/TimelineSidebar.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import moment from 'moment';
 import TimelineSidebar from './TimelineSidebar.Component';
 import { incidents, testIncidents, users } from '../../../mock_endpoints/mockData';
 
@@ -61,9 +62,10 @@ describe('Timeline Sidebar component', () => {
   });
 
   it('should handle date string', () => {
-    // it might fail locally since it only works with GMT timezone
     const dateString = wrapperInstance.handleDateString(new Date('2019-06-06T13:00:38.335Z'));
-    expect(dateString).toEqual('Jun 6th 2019 at 1:00 pm');
+    const expectedTimeFormat = moment('2019-06-06T13:00:38.335Z').format('MMM Do YYYY [at] h:mm a');
+
+    expect(dateString).toEqual(expectedTimeFormat);
   });
 
   it('should initiate the changeStatus action when the value parameter passed to handleStatusChange is not 3', () => {

--- a/src/actions/actionTypes.jsx
+++ b/src/actions/actionTypes.jsx
@@ -17,3 +17,4 @@ export const SEARCH_USER = 'SEARCH_USER';
 export const EDIT_USER = 'EDIT_USER';
 export const DELETE_USER = 'DELETE_USER';
 export const GET_TOKEN_SUCCESS = 'GET_TOKEN_SUCCESS';
+export const GET_SLACKCHATS = 'GET_SLACKCHATS';

--- a/src/actions/timelineAction.jsx
+++ b/src/actions/timelineAction.jsx
@@ -11,6 +11,7 @@ import {
   ADD_CHAT,
   CHANGE_ASSIGNEE,
   ARCHIVE_NOTE,
+  GET_SLACKCHATS,
 } from './actionTypes';
 
 const loadIncident = incidentId => http().get(`/incidents/${incidentId}`);
@@ -135,4 +136,16 @@ export const sendMessage = (incidentId, message) => dispatch => http()
   .then((res) => {
     dispatch(sendMessageSuccess(res.data.data));
   })
+  .catch(error => dispatch(errorAction(error)));
+
+export const getSlackchatSuccess = chats => ({
+  type: GET_SLACKCHATS,
+  chats,
+  isLoading: false,
+  isError: false,
+});
+
+export const getSlackchat = () => dispatch => http()
+  .get('/slack/chats')
+  .then(res => dispatch(getSlackchatSuccess(res.data.data.chats)))
   .catch(error => dispatch(errorAction(error)));

--- a/src/actions/timelineAction.test.js
+++ b/src/actions/timelineAction.test.js
@@ -72,6 +72,12 @@ describe('async actions', () => {
         statusCode: 401,
       },
     },
+    {
+      type: types.GET_SLACKCHATS,
+      chats: allChats,
+      isLoading: false,
+      isError: false,
+    },
   ];
 
   it('creates all appropriate actions when loading incident details', (done) => {
@@ -221,5 +227,14 @@ describe('async actions', () => {
 
     return mockDispatchAction(store, actions.sendMessage(incidentId, userId, message),
       [expectedActions[8]]);
+  });
+
+  it('dispatches action to fetch all chats', () => {
+    const mockResponse = httpResponse(200, { data: { chats: allChats } });
+    const store = mockStore();
+    moxios.wait(() => mockAxios(mockResponse, moxios, true));
+
+    return mockDispatchAction(store, actions.getSlackchat(),
+      [expectedActions[9]]);
   });
 });

--- a/src/pages/IncidentTimeline/IncidentTimeline.Component.jsx
+++ b/src/pages/IncidentTimeline/IncidentTimeline.Component.jsx
@@ -13,6 +13,7 @@ import {
   handleCC,
   changeStatus,
   sendMessage,
+  getSlackchat,
 } from '../../actions/timelineAction';
 import { fetchStaff } from '../../actions/staffAction';
 import './IncidentTimeline.scss';
@@ -167,6 +168,7 @@ export const mapDispatchToProps = dispatch => bindActionCreators(
     changeStatus,
     sendMessage,
     fetchStaff,
+    getSlackchat,
   },
   dispatch,
 );

--- a/src/reducers/selectedIncidentReducer.jsx
+++ b/src/reducers/selectedIncidentReducer.jsx
@@ -7,6 +7,7 @@ import {
   ARCHIVE_NOTE,
   CHANGE_STATUS,
   CHANGE_ASSIGNEE,
+  GET_SLACKCHATS,
 } from '../actions/actionTypes';
 
 const selectedIncidentReducer = (state = initialState.selectedIncident, action) => {
@@ -32,6 +33,8 @@ const selectedIncidentReducer = (state = initialState.selectedIncident, action) 
       };
     case ADD_CHAT:
       return { ...state, chats: [...state.chats, action.chat] };
+    case GET_SLACKCHATS:
+      return { ...state, chats: [...action.chats] };
 
     default:
       return state;

--- a/src/reducers/selectedIncidentReducer.test.js
+++ b/src/reducers/selectedIncidentReducer.test.js
@@ -94,4 +94,16 @@ describe('Reducers :: Selected Incident Reducer', () => {
     
     expect(expectedState.id).toEqual('cjezu2kr700010wx1yy6kxu5z');
   });
+
+  it('should handle GET_SLACKCHATS', () => {
+    const action = {
+      type: ActionTypes.GET_SLACKCHATS,
+      chats: allChats,
+      isLoading: false,
+      isError: false,
+    };
+    const expectedState = reducer(newInitialState, action);
+    
+    expect(expectedState.chats.length).toBe(allChats.length);
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
This PR fetches slack chats from the database, on the chats page

#### Description of Task to be completed?
As a user, I should be able to add a chat on slack and be able to view it on the chats page.

#### How should this be manually tested?
- Populate the `slackEvents` table
- On the single incident page, click on the Chats menu tab on the top right to view the incident chats.


#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#165057910](https://www.pivotaltracker.com/n/projects/2117172/stories/165057910)

#### Screenshots (if appropriate)
<img width="1424" alt="Screenshot 2019-07-31 at 4 37 44 PM" src="https://user-images.githubusercontent.com/38390690/62278414-efc33d80-b43f-11e9-9798-3ff53c41b41b.png">


