### PR TITLE
#167725518 fix change of incident status on timeline sidebar

### DIFF
--- a/src/Components/TimelineSidebar/TimelineSidebar.Component.jsx
+++ b/src/Components/TimelineSidebar/TimelineSidebar.Component.jsx
@@ -73,9 +73,13 @@ class TimelineSidebar extends Component {
 
   /**
    * Method to handle status change for an incident
+   * @param {event}
+   * 
+   * @returns {void}
    */
-  handleStatusChange = (e, index, value) => {
-    e.preventDefault();
+  handleStatusChange = (event) => {
+    event.preventDefault();
+    const { target: { value } } = event;
     if (value === 3) {
       this.setState({ reportDialogOpen: !this.state.reportDialogOpen, resolveValue: value });
     } else {

--- a/src/Components/TimelineSidebar/TimelineSidebar.test.js
+++ b/src/Components/TimelineSidebar/TimelineSidebar.test.js
@@ -50,7 +50,12 @@ describe('Timeline Sidebar component', () => {
   });
 
   it('should change the reportDialogOpen and resolveValue states when handleStatusChange is called 3 as the value parameter', () => {
-    wrapperInstance.handleStatusChange({ preventDefault: jest.fn() }, 1, 3);
+    wrapperInstance.handleStatusChange({
+      preventDefault: jest.fn(),
+      target: {
+        value: 3,
+      },
+    });
     expect(wrapperInstance.state.reportDialogOpen).toBeTruthy();
     expect(wrapperInstance.state.resolveValue).toEqual(3);
   });
@@ -62,7 +67,12 @@ describe('Timeline Sidebar component', () => {
   });
 
   it('should initiate the changeStatus action when the value parameter passed to handleStatusChange is not 3', () => {
-    wrapperInstance.handleStatusChange({ preventDefault: jest.fn() }, 1, 4);
+    wrapperInstance.handleStatusChange({
+      preventDefault: jest.fn(),
+      target: {
+        value: 2,
+      },
+    });
     expect(props.changeStatus).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
#### What does this PR do?
fix change of incident status on timeline sidebar. Selecting an option from the dropdown menu should trigger a change of status.
#### Description of Task to be completed?
- modify the handle status change method
- fix failing tests due to changes
#### How should this be manually tested?
- Clone this project
- checkout this branch `bg-fix-change-status-167725518`
- Run the application.
- Log in to the application and select a single incident.
- Follow GIF below.
#### What are the relevant pivotal tracker stories?
[ #167725518](https://www.pivotaltracker.com/story/show/167725518)
#### Screenshots (if appropriate)
Before:
![b4TMSB](https://user-images.githubusercontent.com/40595048/62544441-73c65c80-b868-11e9-95de-7a4b378e8abf.gif)
After:
![afterTimline](https://user-images.githubusercontent.com/40595048/62544466-7b860100-b868-11e9-9ea1-0ed17572a085.gif)

