### PR TITLE
fix assigned user avatar doesn't display correctly on incident sidebar

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
         }
     },
     "rules": {
+        "linebreak-style":0,
         "arow-parens": 0,
         "consistent-return": 0,
         "quotes": [2, "single"],

--- a/src/Components/TimelineSidebar/TimelineSidebar.Component.jsx
+++ b/src/Components/TimelineSidebar/TimelineSidebar.Component.jsx
@@ -167,17 +167,16 @@ class TimelineSidebar extends Component {
    * 
    * @return {<img/>}
    */
-  renderCCdImage =() => {
+  renderCCdImage = () => {
     const { incident } = this.props;
-    const ccdAssociates = incident.assignees.filter(user => user.assignedRole || user.assigneeIncidents.assignedRole === 'ccd');
+
+    const ccdAssociates = incident.assignees.filter(
+      user => user.assignedRole || user.assigneeIncidents.assignedRole,
+    );
     return ccdAssociates.map(imageUrl => (
-      <img
-       className="ccd-avatar" 
-       src={imageUrl.imageUrl}
-       alt="Avatar"
-      />
+      <img className="ccd-avatar" src={imageUrl.imageUrl} alt="Avatar" />
     ));
-  }
+  };
 
   onSelectClose = (values) => {
     const ccdUsers = values.map(

--- a/src/Components/TimelineSidebar/TimelineSidebar.test.js
+++ b/src/Components/TimelineSidebar/TimelineSidebar.test.js
@@ -164,4 +164,18 @@ describe('Timeline Sidebar component', () => {
 
     expect(wrapper.find('WithStyles(MenuItem)').at(3).length).toEqual(1);
   });
+
+  it('should display associated users avatars', () => {
+    expect(wrapper.find('.ccd-avatar').length).toEqual(2);
+  });
+
+  it('should not display any avatar if assignee list is empty', () => {
+    wrapper.setProps({
+      incident: {
+        ...props.incident,
+        assignees: [],
+      },
+    });
+    expect(wrapper.find('.ccd-avatar').length).toEqual(0);
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
fix to assigned user avatar doesn't display as expected.

#### How should this be manually tested?

1. Navigate to the incident timeline page.
2. Assign a user to the incident OR if there was already assigned user then CC a user.
3. Check all the associated users avatars show up correctly.

#### What are the relevant pivotal tracker stories?
[167755524](https://www.pivotaltracker.com/n/projects/2117172/stories/167755524)
#### Screenshots (if appropriate)
before:
![bug](https://user-images.githubusercontent.com/6759467/62622164-01b04f00-b91e-11e9-9255-efbd09e6844d.gif)

after:
![fix](https://user-images.githubusercontent.com/6759467/62622326-69ff3080-b91e-11e9-8c61-b583c4d2a652.gif)

