### PR TITLE
#168474182 fix the user interface display

### DIFF
--- a/src/Components/InputBox/InputBox.scss
+++ b/src/Components/InputBox/InputBox.scss
@@ -1,7 +1,7 @@
 @import "../../theme";
 
 .message-container {
-  position: sticky;
+  position: absolute;
   bottom: 0px;
   display: flex;
   flex-direction: row;

--- a/src/Components/TimelineChat/TimelineChat.Component.jsx
+++ b/src/Components/TimelineChat/TimelineChat.Component.jsx
@@ -46,7 +46,7 @@ class TimelineChat extends Component {
 
     return dateString;
   }
-  
+
   // moment(date).format('MMMM Do YYYY');
 
   groupChatByDate = (chats) => {
@@ -76,25 +76,27 @@ class TimelineChat extends Component {
     const dayChats = this.sortGroupedChats(this.groupChatByDate(this.props.incident.chats));
     return (
       <div className="chat-container">
-        {Object.entries(dayChats).map(([, { date, chats }]) => (
-          <List className="chat-list" key={date}>
-            <div className="chat-date">{this.groupedChatsDate(date)}</div>
-            {chats.length > 0 ? (
-              chats.map((chat, i) => (
-                <ListItem key={i}>
-                  <Chat chat={chat} handleDateString={this.handleDateString} />
-                </ListItem>
-                
-              ))
-            ) : (
-              <div className="no-message">
-                <p>No Messages</p>
-              </div>
-            )}
-            <div className="chat-divider" />
-          </List>
-        ))}
-        <InputBox 
+        <div className="chat-messages">
+          {Object.entries(dayChats).map(([, { date, chats }]) => (
+            <List className="chat-list" key={date}>
+              <div className="chat-date">{this.groupedChatsDate(date)}</div>
+              {chats.length > 0 ? (
+                chats.map((chat, i) => (
+                  <ListItem key={i}>
+                    <Chat chat={chat} handleDateString={this.handleDateString} />
+                  </ListItem>
+
+                ))
+              ) : (
+                <div className="no-message">
+                  <p>No Messages</p>
+                </div>
+              )}
+              <div className="chat-divider" />
+            </List>
+          ))}
+        </div>
+        <InputBox
           onSubmit={this.handlePostMessage}
           value={this.state.message}
           onChange={this.handleChange}

--- a/src/Components/TimelineChat/TimelineChat.scss
+++ b/src/Components/TimelineChat/TimelineChat.scss
@@ -1,8 +1,12 @@
 @import "../../theme";
 .chat-container {
   width: 100%;
-  height: 35vh;
-  overflow: auto;
+  height: 48.3vh;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  overflow-y: scroll;
+
   .chat-list {
     overflow: scroll;
     padding-top: 16px !important;

--- a/src/Components/TimelineNotes/TimelineNotes.Component.jsx
+++ b/src/Components/TimelineNotes/TimelineNotes.Component.jsx
@@ -169,7 +169,7 @@ export default class TimelineNotes extends Component {
           <span className={!this.state.myNotes ? 'toggle-label' : 'toggle-label all'}>All Notes</span>
         </div>
         <div className="notes-container">
-          <List>
+          <List className="notes-messages">
             {/* Iterate through the each day entry */}
             {Object.entries(dayNotes).map(([, { date, notes }]) => (
               <List className="notes-list" key={date}>
@@ -213,8 +213,8 @@ export default class TimelineNotes extends Component {
             }
           </List>
           <div className="message-border" />
-          
-          <InputBox 
+
+          <InputBox
             onSubmit={this.handleAddNote}
             value={this.state.content}
             onChange={this.handleChange}

--- a/src/Components/TimelineNotes/TimelineNotes.scss
+++ b/src/Components/TimelineNotes/TimelineNotes.scss
@@ -38,7 +38,7 @@
 }
 
 .notes-container {
-  height: 75vh;
+  height: 40vh;
   display: flex;
   justify-content: center;
   flex-direction: column;
@@ -155,80 +155,6 @@
         color: #000000;
         text-align: center;
         padding: 2.5rem;
-      }
-    }
-  }
-
-  .message-container {
-    position: fixed;
-    bottom: 0px;
-    display: flex;
-    flex-direction: row;
-    background-color: #fff;
-    width: 75vw;
-    justify-content: space-between;
-    align-items: center;
-    padding-bottom: 50px;
-
-    .attachment-icon {
-      cursor: pointer;
-      margin-left: calc(31vw - 380px);
-      margin-right: 25px;
-      margin-top: 15px;
-      width: 24px;
-      height: 24px;
-      fill: rgba(0, 0, 0, 0.6) !important;
-    }
-
-    .message-input {
-      flex: 1 1 auto;
-      height: 60px;
-      max-width: 980px;
-      border-bottom: 1.6px solid black;
-
-      .text-input {
-        text-align: center;
-        padding-top: 15px;
-        width: 100% !important;
-
-        input[type="text"] {
-          font-size: 18px !important;
-        }
-
-        align-items: center;
-      }
-    }
-
-    .message-icon {
-      cursor: pointer;
-      height: 24px;
-      margin-top: 5px;
-      margin-left: 5px;
-      opacity: 0.7;
-    }
-
-    .at-icon {
-      cursor: pointer;
-      font-family: 'Source Sans Pro';
-      font-size: 24px;
-      margin-top: 15px;
-      margin-left: 15px;
-      opacity: 0.6;
-    }
-
-    .add-button {
-      cursor: pointer;
-      margin-top: 15px;
-      margin-left: 25px;
-      width: 130px;
-      height: 40px;
-      box-shadow: 1px 2px 3px 1px rgba(0, 0, 0, 0.1);
-      border-radius: 8px;
-      border-style: none;
-
-      &:hover {
-        transform: scale(1.1, 1.1);
-        background-color: #f5f5f5;
       }
     }
   }


### PR DESCRIPTION
#### What does this PR do?
- This pull request aims to fix the user interface bug that renders that timeline page incorrectly. 

#### Description of Task to be completed?
- The timeline panel had incorrect rendering whereby the add message panels in both the notes and chat tabs were rendered outside of the viewport. This PR readjusts the viewport height and adds additional nesting of the divs to fix the issue. 
#### How should this be manually tested?
 - Startup the application with both the front end and backend. The wirebot is not required if you have existing reports. If not you will need to start it up to create a new report.
 - Click on any report to go to the timeline. On the page the note and chats tabs should be rendered correctly and switching between the two tabs should reveal the relevant input box. i.e the chats tab should have an "Type a message" input box and the notes tab should have an "Add a note" input box.

#### Screenshots
<img width="1099" alt="Screen Shot 2019-09-13 at 11 29 40" src="https://user-images.githubusercontent.com/25079238/64848436-d81fcd00-d619-11e9-9a8a-6bb37cedd8ae.png">
<img width="1083" alt="Screen Shot 2019-09-13 at 11 29 32" src="https://user-images.githubusercontent.com/25079238/64848439-d9e99080-d619-11e9-97b1-e2600e99588a.png">

#### What are the relevant pivotal tracker stories?
[#168474182](https://www.pivotaltracker.com/story/show/168474182)
